### PR TITLE
rework parse-arg, stable param order in help, no implicit definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Help:
 <!-- auto-generated, do not modify here but in src/releasing/update-version-README.sh -->
 ```text
 Parameters:
--f|--file            (optional) the file where search & replace shall be done -- default: ./README.md
--v|--version         the version which shall be used
+-v|--version    the version which shall be used
+-f|--file       (optional) the file where search & replace shall be done -- default: ./README.md
 
 Examples:
 # update version for ./README.md
@@ -110,8 +110,8 @@ Help:
 <!-- auto-generated, do not modify here but in src/releasing/update-version-scripts.sh -->
 ```text
 Parameters:
--d|--directory       (optional) the working directory -- default: ./src
--v|--version         the version which shall be used
+-v|--version    the version which shall be used
+-d|--directory  (optional) the working directory -- default: ./src
 
 Examples:
 # update version to v0.1.0 for all *.sh in ./src and subdirectories
@@ -164,8 +164,8 @@ Help:
 <!-- auto-generated, do not modify here but in src/releasing/toggle-sections.sh -->
 ```text
 Parameters:
--f|--file            (optional) the file where search & replace shall be done -- default: ./README.md
--c|--command         either 'main' or 'release'
+-c|--command    either 'main' or 'release'
+-f|--file       (optional) the file where search & replace shall be done -- default: ./README.md
 
 Examples:
 # comment the release sections in ./README.md and uncomment the main sections
@@ -204,8 +204,8 @@ Help:
 <!-- auto-generated, do not modify here but in src/releasing/sneak-peek-banner.sh -->
 ```text
 Parameters:
--f|--file            (optional) the file where search & replace shall be done -- default: ./README.md
--c|--command         either 'show' or 'hide'
+-c|--command    either 'show' or 'hide'
+-f|--file       (optional) the file where search & replace shall be done -- default: ./README.md
 
 Examples:
 # hide the sneak peek banner in ./README.md
@@ -253,47 +253,42 @@ Full usage example:
 ```bash
 #!/usr/bin/env bash
 
-declare -A params
-declare -A help
-
 # declare the variables where the arguments shall be stored (used as identifier afterwards)
-declare directory pattern
+declare directory pattern version
 
-# define the regex which is used to identify the argument `directory`
-params[directory]='-d|--directory'
-# optional: define an explanation for the argument `directory` which will show up in `--help`
-help[directory]='(optional) the working directory -- default: .'
-
+# parameter definitions where each parameter definition consists of three values (separated via space)
+# VARIABLE_NAME PATTERN HELP_TEXT
+# where the HELP_TEXT is optional in the sense of that you can use an empty string
 # in case you use shellcheck then you need to suppress the warning for the last variable definition of params
-# as shellcheck doesn't get that we are passing `params` to parseArguments ¯\_(ツ)_/¯
+# as shellcheck doesn't get that we are passing `params` to parseArguments ¯\_(ツ)_/¯ (an open issue of shellcheck)
 # shellcheck disable=SC2034
-params[pattern]='-p|--pattern'
-# `help` is used implicitly in parse-args, here shellcheck cannot know it and you need to disable the rule
-# shellcheck disable=SC2034
-help[pattern]='pattern used during analysis'
-
-# optional: you can define examples which are included in the help text
+declare params=(
+  directory '-d|--directory' '(optional) the working directory -- default: .'
+  pattern '-p|--pattern' 'pattern used during analysis'
+  version '-v|--version' ''
+)
+# optional: you can define examples which are included in the help text -- use an empty string for no example
 declare examples
 # `examples` is used implicitly in parse-args, here shellcheck cannot know it and you need to disable the rule
-# shellcheck disable=SC2034
-examples=$(cat << EOM
+examples=$(
+  cat <<EOM
 # analyse in the current directory using the specified pattern
-analysis.sh -p "%{21}"
+analysis.sh -p "%{21}" -v v0.1.0
 EOM
 )
 
 declare current_dir
-current_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
+current_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
 # Assuming parse-args.sh is in the same directory as your script
 source "$current_dir/parse-args.sh"
 
-parseArguments params "$@"
+parseArguments params "$examples" "$@"
 # in case there are optional parameters, then fill them in here before calling checkAllArgumentsSet
 if ! [ -v directory ]; then directory="."; fi
-checkAllArgumentsSet params
+checkAllArgumentsSet params "$examples"
 
 # pass your variables storing the arguments to other scripts
-echo "d: $directory, p: $pattern"
+echo "d: $directory, p: $pattern, v: $version"
 ```
 
 </utility-parse-args>

--- a/src/releasing/sneak-peek-banner.sh
+++ b/src/releasing/sneak-peek-banner.sh
@@ -23,50 +23,41 @@
 ###################################
 set -e
 
-declare -A params
-declare -A help
-
 declare command file
-
-params[command]='-c|--command'
-help[command]="either 'show' or 'hide'"
-
 # shellcheck disable=SC2034
-params[file]='-f|--file'
-# shellcheck disable=SC2034
-help[file]='(optional) the file where search & replace shall be done -- default: ./README.md'
+declare params=(
+  command '-c|--command' "either 'show' or 'hide'"
+  file '-f|--file' '(optional) the file where search & replace shall be done -- default: ./README.md'
+)
 
 declare examples
-# shellcheck disable=SC2034
-examples=$(cat << EOM
+examples=$(
+  cat <<EOM
 # hide the sneak peek banner in ./README.md
 sneak-peek-banner.sh -c hide
 
 # show the sneak peek banner in ./docs/index.md
 sneak-peek-banner.sh -c show -f ./docs/index.md
-
 EOM
 )
 
 declare current_dir
-current_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
+current_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
 # Assuming parse-args.sh is in the same directory as your script
 source "$current_dir/../utility/parse-args.sh"
 
-parseArguments params "$@"
+parseArguments params "$examples" "$@"
 # in case there are optional parameters, then fill them in here before calling checkAllArgumentsSet
 if ! [ -v file ]; then file="./README.md"; fi
-checkAllArgumentsSet params
+checkAllArgumentsSet params "$examples"
 
 if [ "$command" == "show" ]; then
   echo "show sneak peek banner in $file"
   perl -0777 -i -pe 's/<!(---\n❗ You are taking[\S\s]+?---)>/$1/;' "$file"
-elif [  "$command" == "hide" ]; then
+elif [ "$command" == "hide" ]; then
   echo "hide sneak peek banner in $file"
   perl -0777 -i -pe 's/((?<!<!)---\n❗ You are taking[\S\s]+?---)/<!$1>/;' "$file"
 else
   echo >&2 "only 'show' and 'hide' are supported as command. Following the output of calling --help"
-  printHelp params
+  printHelp params help "$examples"
 fi
-
-

--- a/src/releasing/update-version-README.sh
+++ b/src/releasing/update-version-README.sh
@@ -23,40 +23,33 @@
 ###################################
 set -e
 
-declare -A params
-declare -A help
-
 declare version file
-
-params[version]='-v|--version'
-help[version]='the version which shall be used'
-
 # shellcheck disable=SC2034
-params[file]='-f|--file'
-# shellcheck disable=SC2034
-help[file]='(optional) the file where search & replace shall be done -- default: ./README.md'
+declare params=(
+  version '-v|--version' 'the version which shall be used'
+  file '-f|--file' '(optional) the file where search & replace shall be done -- default: ./README.md'
+)
 
 declare examples
-# shellcheck disable=SC2034
-examples=$(cat << EOM
+examples=$(
+  cat <<EOM
 # update version for ./README.md
 update-version-README.sh -v v0.1.0
 
 # update version for ./docs/index.md
 update-version-README.sh -v v0.1.0 -f ./docs/index.md
-
 EOM
 )
 
 declare current_dir
-current_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
+current_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
 # Assuming parse-args.sh is in the same directory as your script
 source "$current_dir/../utility/parse-args.sh"
 
-parseArguments params "$@"
+parseArguments params "$examples" "$@"
 # in case there are optional parameters, then fill them in here before calling checkAllArgumentsSet
 if ! [ -v file ]; then file="./README.md"; fi
-checkAllArgumentsSet params
+checkAllArgumentsSet params "$examples"
 
 echo "set version $version for Download badges and sneak peek banner in $file"
 

--- a/src/releasing/update-version-scripts.sh
+++ b/src/releasing/update-version-scripts.sh
@@ -24,45 +24,37 @@
 
 set -e
 
-declare -A params
-declare -A help
-
 declare version directory
-
-params[version]='-v|--version'
-help[version]='the version which shall be used'
-
 # shellcheck disable=SC2034
-params[directory]='-d|--directory'
-# shellcheck disable=SC2034
-help[directory]='(optional) the working directory -- default: ./src'
+declare params=(
+  version '-v|--version' 'the version which shall be used'
+  directory '-d|--directory' '(optional) the working directory -- default: ./src'
+)
 
 declare examples
-# shellcheck disable=SC2034
-examples=$(cat << EOM
+examples=$(
+  cat <<EOM
 # update version to v0.1.0 for all *.sh in ./src and subdirectories
 update-version-scripts.sh -v v0.1.0
 
 # update version to v0.1.0 for all *.sh in ./scripts and subdirectories
 update-version-scripts.sh -v v0.1.0 -d ./scripts
-
 EOM
 )
 
 declare current_dir
-current_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
+current_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
 # Assuming parse-args.sh is in the same directory as your script
 source "$current_dir/../utility/parse-args.sh"
 
-parseArguments params "$@"
+parseArguments params "$examples" "$@"
 # in case there are optional parameters, then fill them in here before calling checkAllArgumentsSet
 if ! [ -v directory ]; then directory="./src"; fi
-checkAllArgumentsSet params
+checkAllArgumentsSet params "$examples"
 
 find "$directory" -name "*.sh" \
-  -print0 | while read -r -d $'\0' script
-    do
-      perl -0777 -i \
-         -pe "s/Version:.+(\n[\S\s]+?###+\s+Description)/Version: $version\$1/g;" \
-         "$script"
-    done
+  -print0 | while read -r -d $'\0' script; do
+  perl -0777 -i \
+    -pe "s/Version:.+(\n[\S\s]+?###+\s+Description)/Version: $version\$1/g;" \
+    "$script"
+done

--- a/src/utility/parse-args.doc.sh
+++ b/src/utility/parse-args.doc.sh
@@ -1,43 +1,38 @@
 #!/usr/bin/env bash
 
-declare -A params
-declare -A help
-
 # declare the variables where the arguments shall be stored (used as identifier afterwards)
-declare directory pattern
+declare directory pattern version
 
-# define the regex which is used to identify the argument `directory`
-params[directory]='-d|--directory'
-# optional: define an explanation for the argument `directory` which will show up in `--help`
-help[directory]='(optional) the working directory -- default: .'
-
+# parameter definitions where each parameter definition consists of three values (separated via space)
+# VARIABLE_NAME PATTERN HELP_TEXT
+# where the HELP_TEXT is optional in the sense of that you can use an empty string
 # in case you use shellcheck then you need to suppress the warning for the last variable definition of params
-# as shellcheck doesn't get that we are passing `params` to parseArguments ¯\_(ツ)_/¯
+# as shellcheck doesn't get that we are passing `params` to parseArguments ¯\_(ツ)_/¯ (an open issue of shellcheck)
 # shellcheck disable=SC2034
-params[pattern]='-p|--pattern'
-# `help` is used implicitly in parse-args, here shellcheck cannot know it and you need to disable the rule
-# shellcheck disable=SC2034
-help[pattern]='pattern used during analysis'
-
-# optional: you can define examples which are included in the help text
+declare params=(
+  directory '-d|--directory' '(optional) the working directory -- default: .'
+  pattern '-p|--pattern' 'pattern used during analysis'
+  version '-v|--version' ''
+)
+# optional: you can define examples which are included in the help text -- use an empty string for no example
 declare examples
 # `examples` is used implicitly in parse-args, here shellcheck cannot know it and you need to disable the rule
-# shellcheck disable=SC2034
-examples=$(cat << EOM
+examples=$(
+  cat <<EOM
 # analyse in the current directory using the specified pattern
-analysis.sh -p "%{21}"
+analysis.sh -p "%{21}" -v v0.1.0
 EOM
 )
 
 declare current_dir
-current_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
+current_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
 # Assuming parse-args.sh is in the same directory as your script
 source "$current_dir/parse-args.sh"
 
-parseArguments params "$@"
+parseArguments params "$examples" "$@"
 # in case there are optional parameters, then fill them in here before calling checkAllArgumentsSet
 if ! [ -v directory ]; then directory="."; fi
-checkAllArgumentsSet params
+checkAllArgumentsSet params "$examples"
 
 # pass your variables storing the arguments to other scripts
-echo "d: $directory, p: $pattern"
+echo "d: $directory, p: $pattern, v: $version"

--- a/src/utility/parse-args.sh
+++ b/src/utility/parse-args.sh
@@ -16,47 +16,42 @@
 #
 #    #!/usr/bin/env bash
 #
-#    declare -A params
-#    declare -A help
-#
 #    # declare the variables where the arguments shall be stored (used as identifier afterwards)
-#    declare directory pattern
+#    declare directory pattern version
 #
-#    # define the regex which is used to identify the argument `directory`
-#    params[directory]='-d|--directory'
-#    # optional: define an explanation for the argument `directory` which will show up in `--help`
-#    help[directory]='(optional) the working directory -- default: .'
-#
+#    # parameter definitions where each parameter definition consists of three values (separated via space)
+#    # VARIABLE_NAME PATTERN HELP_TEXT
+#    # where the HELP_TEXT is optional in the sense of that you can use an empty string
 #    # in case you use shellcheck then you need to suppress the warning for the last variable definition of params
-#    # as shellcheck doesn't get that we are passing `params` to parseArguments ¯\_(ツ)_/¯
+#    # as shellcheck doesn't get that we are passing `params` to parseArguments ¯\_(ツ)_/¯ (an open issue of shellcheck)
 #    # shellcheck disable=SC2034
-#    params[pattern]='-p|--pattern'
-#    # `help` is used implicitly in parse-args, here shellcheck cannot know it and you need to disable the rule
-#    # shellcheck disable=SC2034
-#    help[pattern]='pattern used during analysis'
-#
-#    # optional: you can define examples which are included in the help text
+#    declare params=(
+#      directory '-d|--directory' '(optional) the working directory -- default: .'
+#      pattern '-p|--pattern' 'pattern used during analysis'
+#      version '-v|--version' ''
+#    )
+#    # optional: you can define examples which are included in the help text -- use an empty string for no example
 #    declare examples
 #    # `examples` is used implicitly in parse-args, here shellcheck cannot know it and you need to disable the rule
-#    # shellcheck disable=SC2034
-#    examples=$(cat << EOM
+#    examples=$(
+#      cat <<EOM
 #    # analyse in the current directory using the specified pattern
-#    analysis.sh -p "%{21}"
+#    analysis.sh -p "%{21}" -v v0.1.0
 #    EOM
 #    )
 #
 #    declare current_dir
-#    current_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
+#    current_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
 #    # Assuming parse-args.sh is in the same directory as your script
 #    source "$current_dir/parse-args.sh"
 #
-#    parseArguments params "$@"
+#    parseArguments params "$examples" "$@"
 #    # in case there are optional parameters, then fill them in here before calling checkAllArgumentsSet
 #    if ! [ -v directory ]; then directory="."; fi
-#    checkAllArgumentsSet params
+#    checkAllArgumentsSet params "$examples"
 #
 #    # pass your variables storing the arguments to other scripts
-#    echo "d: $directory, p: $pattern"
+#    echo "d: $directory, p: $pattern, v: $version"
 #
 #######  Limitations  #############
 #
@@ -67,29 +62,69 @@
 
 set -e
 
+function checkParameterDefinitionIsTriple() {
+  local -n paramArr2=$1
+  local arrLength=${#paramArr2[@]}
+
+  if ! ((arrLength % 3 == 0)); then
+    printf >&2 "\033[1;31mERROR: parameter definition is broken\033[0m for \033[1;34m%s\033[0m in %s\n" "${!paramArr2}" "${BASH_SOURCE[2]}"
+    echo >&2 "each parameter definition should consist of 3 values."
+    echo >&2 "following how we split the definitions:"
+
+    for ((i = 0; i < arrLength; i += 3)); do
+      if ((i + 2 < arrLength)); then
+        printf >&2 '"%s" "%s" "%s"\n' "${paramArr2[$i]}" "${paramArr2[$i + 1]}" "${paramArr2[$i + 2]}"
+      else
+        printf >&2 "\033[1;33mleftovers:\033[0m\n"
+        printf '"%s"' "${paramArr2[$i]}"
+        if ((i + 1 < arrLength)); then
+          printf ' "%s"' "${paramArr2[$i + 1]}"
+        fi
+      fi
+    done
+    exit 1
+  fi
+}
+
 function parseArguments {
-  local -n parameterNames=$1
+  local -n paramArr1=$1
+  local examples=$2
   shift
+  shift
+
+  checkParameterDefinitionIsTriple paramArr1
+
+  local arrLength="${#paramArr1[@]}"
 
   while [[ $# -gt 0 ]]; do
     argName="$1"
+    if [[ "$argName" == "--help" ]]; then
+      printHelp paramArr1 "$examples"
+      exit 0
+    fi
+
     expectedName=0
-    for paramName in "${!parameterNames[@]}"; do
-      regex="^(${parameterNames[$paramName]})$"
+    for ((i = 0; i < arrLength; i += 3)); do
+      local paramName="${paramArr1[i]}"
+      local pattern="${paramArr1[i + 1]}"
+      regex="^($pattern)$"
       if [[ "$argName" =~ $regex ]]; then
         # that's where the black magic happens, we are assigning to global variables here
+        if [ -n "$2" ]; then
+          printf >&2 "\033[1;31mERROR\033[0m: no value defined for parameter \033[1;34m%s\033[0m\n" "$pattern"
+          echo >&2 "following the help documentation:"
+          printHelp paramArr1 "$examples"
+          exit 2
+        fi
         printf -v "${paramName}" "%s" "$2"
         expectedName=1
         shift
       fi
     done
-    if [[ "$argName" == "--help" ]]; then
-      printHelp parameterNames
-      exit 0
-    fi
+
     if [ "$expectedName" -eq 0 ]; then
       if [[ "$argName" =~ ^- ]]; then
-        printf "\033[1;33mignored argument %s (and its value)\033[0m\n" "$argName"
+        printf "\033[1;33mignored argument %s (and its value %s)\033[0m\n" "$argName" "$2"
       fi
     fi
     shift
@@ -97,36 +132,58 @@ function parseArguments {
 }
 
 function printHelp {
-  local -n names=$1
-  printf "\n\033[1;33mParameters:\033[0m\n"
-  for paramName in "${!names[@]}"; do
-    if [[ -v help[@] ]] && [ "${help[$paramName]+_}" ] ; then
-      printf "%-20s %s\n" "${names[$paramName]}" "${help[$paramName]}"
-    else
-      echo "${names[$paramName]} $help"
+  local -n paramArr3=$1
+  local examples=$2
+  checkParameterDefinitionIsTriple paramArr3
+
+  local arrLength="${#paramArr3[@]}"
+
+  local maxLength=15
+  for ((i = 0; i < arrLength; i += 3)); do
+    local paramName="${paramArr3[i]}"
+    local length=$((${#paramArr3[i]} + 5))
+    if ((length > maxLength)); then
+      maxLength="$length"
     fi
   done
-  if [ -v examples ]; then
+
+  printf "\n\033[1;33mParameters:\033[0m\n"
+  for ((i = 0; i < arrLength; i += 3)); do
+    local pattern="${paramArr3[i + 1]}"
+    local help="${paramArr3[i + 2]}"
+
+    if [[ -n "$help" ]]; then
+      printf "%-${maxLength}s %s\n" "$pattern" "$help"
+    else
+      echo "$pattern"
+    fi
+  done
+  if [ -n "$examples" ]; then
     printf "\n\033[1;33mExamples:\033[0m\n"
     echo "$examples"
   fi
 }
 
 function checkAllArgumentsSet {
-  local -n parameterNames=$1
+  local -n paramArr4=$1
+  local examples=$2
+  checkParameterDefinitionIsTriple paramArr4
+
+  local arrLength="${#paramArr4[@]}"
   local good=1
-  for paramName in "${!parameterNames[@]}"; do
+  for ((i = 0; i < arrLength; i += 3)); do
+    local paramName="${paramArr4[i]}"
     if ! [ -v "$paramName" ]; then
-      printf >&2 "\033[1;31mERROR: %s not set\n\033[0m" "$paramName"
+      printf >&2 "\033[1;31mERROR\033[0m: %s not set\n" "$paramName"
       good=0
     fi
   done
   if [ "$good" -eq 0 ]; then
     echo >&2 ""
     echo >&2 "following the help documentation:"
-    printHelp >&2 parameterNames
+    printHelp >&2 paramArr4 "$examples"
     echo >&2 ""
     echo >&2 "use --help to see this list"
-    exit 1
+    exit 3
   fi
 }


### PR DESCRIPTION
i.e. one has to pass help and examples which means that they can also
be named differently. This will enable that parse-args can be used for
command based scripts, i.e. first argument is command and the rest are
arguments specific to this command.



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/tegonal/scripts/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
