### PR TITLE
also check that a non-associative array is passed

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -81,7 +81,7 @@ if ! [ "$prepareOnly" == "true" ]; then
   git push
   git tag "$version"
 
-  "$current_dir/." "$nextVersion"
+  "$current_dir/prepare-next-dev-cycle.sh" "$nextVersion"
 
   git push origin "$version"
 else

--- a/spec/utility/parse-args_spec.sh
+++ b/spec/utility/parse-args_spec.sh
@@ -53,15 +53,27 @@ Describe 'parse_arg.sh'
           declare params=(version -v '' leftOver1)
           When run parseArguments params '' --help
           The status should be failure
+          The stderr should include 'array with parameter definitions is broken'
+          The stderr should include 'The array needs to contain parameter definitions'
+          The stderr should not include 'the first argument needs to be a non-associative array'
           The stderr should include 'leftOver1'
         End
         It 'two leftovers'
           declare params=(version -v '' leftOver1 leftOver2)
           When run parseArguments params '' --help
           The status should be failure
+          The stderr should include 'array with parameter definitions is broken'
           The stderr should include 'leftOver1'
           The stderr should include 'leftOver2'
         End
+      End
+      It 'associative array passed'
+        # shellcheck disable=SC2034
+        declare -A associativeParams=([version]=-v)
+        When run parseArguments associativeParams '' --help
+        The status should be failure
+        The stderr should include 'array with parameter definitions is broken'
+        The stderr should include 'the first argument needs to be a non-associative array'
       End
     End
   End


### PR DESCRIPTION
moreover:
- improve documentation in error message regarding how the array should
  be defined
- check that array is not empty
- exit with 9 in case of illegal arguments
- fix release.sh, prepare-next-dev-cycle was accidentally removed in
  a previous commit



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/tegonal/scripts/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
