### PR TITLE
provide a setup script and explain installation in README

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -33,6 +33,7 @@ body:
         - utility/replace-help-snippet.sh
         - utility/source-once.sh
         - utility/update-bash-docu.sh
+        - setup.sh
     validations:
       required: false
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -27,6 +27,64 @@ For instance, the [README of v0.5.0](https://github.com/tegonal/scripts/tree/v0.
 
 ---
 
+**Table of Content**
+- [Installation](#Installation)
+- [Documentation](#documentation)
+- [Contributors and contribute](#contributors-and-contribute)
+- [License](#license)
+
+# Installation
+
+We recommend you pull the scripts with the help of [gget](https://github.com/tegonal/gget).  
+Alternatively you can 
+[![Download](https://img.shields.io/badge/Download-v0.5.0-%23007ec6)](https://github.com/tegonal/scripts/releases/tag/v0.5.0)
+the sources.
+
+Following the commands you need to execute to setup tegonal scripts via [gget](https://github.com/tegonal/gget).
+```bash
+TEGONAL_SCRIPTS_VERSION="v0.5.0" && \
+gget remote add -r tegonal-scripts -u https://github.com/tegonal/scripts && \
+gget pull -r tegonal-scripts -t "$TEGONAL_SCRIPTS_VERSION" -p src/setup.sh && \
+gget pull -r tegonal-scripts -t "$TEGONAL_SCRIPTS_VERSION" -p src/utility/source-once.sh
+```
+
+Now you can pull the scripts you want in addition via:
+```bash
+gget pull -r tegonal-scripts -t "$TEGONAL_SCRIPTS_VERSION" -p ...
+```
+
+Note that dependencies have to be pulled manually and many scripts depend on scripts defined in `src/utility`.
+Therefore, for simplicity reasons, we recommend you pull all files of `src/utility`:
+```
+gget pull -r tegonal-scripts -t "$TEGONAL_SCRIPTS_VERSION" -p src/utility/
+```
+
+## Sourcing functions
+
+We recommend you use the following code at the beginning of your script in case you want to `source` a file/function
+(in the example below we want to use tegonal's log functions):
+
+<setup>
+
+<!-- auto-generated, do not modify here but in src/setup.sh -->
+```bash
+#!/usr/bin/env bash
+set -eu
+
+if ! [[ -v dir_of_tegonal_scripts ]]; then
+	# Assumes your script is in (root is project folder) e.g. /src or /scripts and
+	# the tegonal scripts have been pulled via gget and put into /lib/tegonal-scripts
+	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/../lib/tegonal-scripts/src")"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
+fi
+
+sourceOnce "$dir_of_tegonal_scripts/utility/log.sh"
+```
+
+</setup>
+
+# Documentation
+
 The scripts are ordered by topic:
 
 - [Quality Assurance](#quality-assurance)
@@ -46,13 +104,10 @@ The scripts are ordered by topic:
   - [Update Documentation](#update-bash-documentation)
 
 
-See also:
-- [Contributors and contribute](#contributors-and-contribute)
-- [License](#license)
 
 # Quality Assurance
 
-The scripts under this topic perform checks or execute qa tools.
+The scripts under this topic (in directory `qa`) perform checks or execute qa tools.
 
 ## runShellcheck
 
@@ -86,7 +141,7 @@ runShellcheck dirs "$sourcePath"
 
 # Releasing
 
-The scripts under this topic perform some steps of your release process.
+The scripts under this topic (in directory `releasing`) perform some steps of your release process.
 
 ## Update Version in README
 
@@ -275,7 +330,7 @@ dir_of_tegonal_scripts="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/n
 
 # Script Utilities
 
-The scripts under this topic are useful for bash programming as such.
+The scripts under this topic (in directory `utility`) are useful for bash programming as such.
 
 ## Parse arguments
 

--- a/scripts/before-pr.sh
+++ b/scripts/before-pr.sh
@@ -10,19 +10,16 @@
 set -eu
 
 if ! [[ -v scriptDir ]]; then
-	declare scriptDir
 	scriptDir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
 	declare -r scriptDir
 fi
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$scriptDir/../src")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 
-source "$dir_of_tegonal_scripts/utility/log.sh"
+sourceOnce "$dir_of_tegonal_scripts/utility/log.sh"
 
 if [[ -x "$(command -v "shellspec")" ]]; then
 	shellspec

--- a/scripts/check-in-bug-template.sh
+++ b/scripts/check-in-bug-template.sh
@@ -10,16 +10,13 @@
 set -eu
 
 if ! [[ -v scriptDir ]]; then
-	declare scriptDir
 	scriptDir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
 	declare -r scriptDir
 fi
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$scriptDir/../src")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 sourceOnce "$dir_of_tegonal_scripts/utility/log.sh"
 

--- a/scripts/prepare-next-dev-cycle.sh
+++ b/scripts/prepare-next-dev-cycle.sh
@@ -10,10 +10,8 @@
 set -eu
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/../src")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 
 sourceOnce "$dir_of_tegonal_scripts/utility/log.sh"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,10 +10,8 @@
 set -eu
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/../src")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 
 source "$dir_of_tegonal_scripts/utility/log.sh"
@@ -54,7 +52,6 @@ git checkout main
 git pull
 
 if ! [[ -v scriptDir ]]; then
-	declare scriptDir
 	scriptDir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
 	declare -r scriptDir
 fi
@@ -65,6 +62,8 @@ fi
 "$dir_of_tegonal_scripts/releasing/toggle-sections.sh" -c release
 "$dir_of_tegonal_scripts/releasing/update-version-README.sh" -v "$version"
 "$dir_of_tegonal_scripts/releasing/update-version-scripts.sh" -v "$version"
+
+perl -0777 -pe "s/(TEGONAL_SCRIPTS_VERSION)=.*/\$1=$version/g" "$scriptDir/../README.md"
 
 rm -rf "$scriptDir/../.gget/gpg"
 mkdir "$scriptDir/../.gget/gpg"

--- a/scripts/run-shellcheck.sh
+++ b/scripts/run-shellcheck.sh
@@ -10,10 +10,8 @@
 set -eu
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/../src")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 
 sourceOnce "$dir_of_tegonal_scripts/qa/run-shellcheck.sh"

--- a/scripts/update-docu.sh
+++ b/scripts/update-docu.sh
@@ -10,10 +10,8 @@
 set -eu
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/../src")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 
 sourceOnce "$dir_of_tegonal_scripts/utility/log.sh"

--- a/src/qa/checks.sh
+++ b/src/qa/checks.sh
@@ -32,10 +32,8 @@
 set -eu
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/..")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 sourceOnce "$dir_of_tegonal_scripts/utility/recursive-declare-p.sh"
 

--- a/src/qa/run-shellcheck.sh
+++ b/src/qa/run-shellcheck.sh
@@ -34,10 +34,8 @@
 set -eu
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/..")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 sourceOnce "$dir_of_tegonal_scripts/qa/checks.sh"
 sourceOnce "$dir_of_tegonal_scripts/utility/log.sh"

--- a/src/releasing/sneak-peek-banner.sh
+++ b/src/releasing/sneak-peek-banner.sh
@@ -24,10 +24,8 @@
 set -eu
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/..")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 sourceOnce "$dir_of_tegonal_scripts/utility/parse-args.sh"
 

--- a/src/releasing/toggle-sections.sh
+++ b/src/releasing/toggle-sections.sh
@@ -28,10 +28,8 @@
 set -eu
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/..")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 sourceOnce "$dir_of_tegonal_scripts/utility/parse-args.sh"
 

--- a/src/releasing/update-version-README.sh
+++ b/src/releasing/update-version-README.sh
@@ -24,10 +24,8 @@
 set -eu
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/..")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 sourceOnce "$dir_of_tegonal_scripts/utility/parse-args.sh"
 

--- a/src/releasing/update-version-scripts.sh
+++ b/src/releasing/update-version-scripts.sh
@@ -24,10 +24,8 @@
 set -eu
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/..")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 sourceOnce "$dir_of_tegonal_scripts/utility/parse-args.sh"
 

--- a/src/setup.doc.sh
+++ b/src/setup.doc.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -eu
+
+if ! [[ -v dir_of_tegonal_scripts ]]; then
+	# Assumes your script is in (root is project folder) e.g. /src or /scripts and
+	# the tegonal scripts have been pulled via gget and put into /lib/tegonal-scripts
+	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/../lib/tegonal-scripts/src")"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
+fi
+
+sourceOnce "$dir_of_tegonal_scripts/utility/log.sh"

--- a/src/setup.sh
+++ b/src/setup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+#    __                          __
+#   / /____ ___ ____  ___  ___ _/ /       This script is provided to you by https://github.com/tegonal/scripts
+#  / __/ -_) _ `/ _ \/ _ \/ _ `/ /        It is licensed under Apache 2.0
+#  \__/\__/\_, /\___/_//_/\_,_/_/         Please report bugs and contribute back your improvements
+#         /___/
+#                                         Version: v0.6.0-SNAPSHOT
+#
+#######  Description  #############
+#
+#  script which should be sourced and sets up variables and functions for the scripts
+#
+#######  Usage  ###################
+#
+###################################
+
+if ! (($# == 1)); then
+	printf >&2 "\033[0;31mERROR\033[0m: You need to pass the path to the tegonal scripts directory as first argument. Following an example\n"
+	echo >&2 "source \"\$dir_of_tegonal_scripts/setup.sh\" \"\$dir_of_tegonal_scripts\""
+	exit
+fi
+
+declare -r dir_of_tegonal_scripts="$1"
+source "$dir_of_tegonal_scripts/utility/source-once.sh"

--- a/src/utility/parse-args.sh
+++ b/src/utility/parse-args.sh
@@ -65,10 +65,8 @@
 set -eu
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/..")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 sourceOnce "$dir_of_tegonal_scripts/utility/log.sh"
 sourceOnce "$dir_of_tegonal_scripts/utility/recursive-declare-p.sh"

--- a/src/utility/parse-fn-args.sh
+++ b/src/utility/parse-fn-args.sh
@@ -60,10 +60,8 @@
 set -eu
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/..")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 sourceOnce "$dir_of_tegonal_scripts/qa/checks.sh"
 sourceOnce "$dir_of_tegonal_scripts/utility/log.sh"

--- a/src/utility/recursive-declare-p.sh
+++ b/src/utility/recursive-declare-p.sh
@@ -43,10 +43,8 @@
 set -eu
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/..")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 sourceOnce "$dir_of_tegonal_scripts/utility/log.sh"
 

--- a/src/utility/replace-help-snippet.sh
+++ b/src/utility/replace-help-snippet.sh
@@ -45,10 +45,8 @@
 set -eu
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/..")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 sourceOnce "$dir_of_tegonal_scripts/utility/parse-fn-args.sh"
 sourceOnce "$dir_of_tegonal_scripts/utility/replace-snippet.sh"

--- a/src/utility/replace-snippet.sh
+++ b/src/utility/replace-snippet.sh
@@ -44,10 +44,8 @@
 set -eu
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/..")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 sourceOnce "$dir_of_tegonal_scripts/utility/parse-fn-args.sh"
 

--- a/src/utility/source-once.doc.sh
+++ b/src/utility/source-once.doc.sh
@@ -6,10 +6,12 @@ declare dir_of_tegonal_scripts
 dir_of_tegonal_scripts="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
 source "$dir_of_tegonal_scripts/utility/source-once.sh"
 
-sourceOnce "foo.sh"  # creates a variable named foo__sh which acts as guard and sources foo.sh
-sourceOnce "foo.sh"  # will source nothing as foo__sh is already defined
-unset foo__sh        # unsets the guard
-sourceOnce "foo.sh"  # is sourced again and the guard established
+sourceOnce "foo.sh"    # creates a variable named foo__sh which acts as guard and sources foo.sh
+sourceOnce "foo.sh"    # will source nothing as foo__sh is already defined
+unset foo__sh          # unsets the guard
+sourceOnce "foo.sh"    # is sourced again and the guard established
+
+
 
 # creates a variable named bar__foo__sh which acts as guard and sources bar/foo.sh
 sourceOnce "bar/foo.sh"

--- a/src/utility/source-once.sh
+++ b/src/utility/source-once.sh
@@ -23,10 +23,12 @@
 #    dir_of_tegonal_scripts="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
 #    source "$dir_of_tegonal_scripts/utility/source-once.sh"
 #
-#    sourceOnce "foo.sh"  # creates a variable named foo__sh which acts as guard and sources foo.sh
-#    sourceOnce "foo.sh"  # will source nothing as foo__sh is already defined
-#    unset foo__sh        # unsets the guard
-#    sourceOnce "foo.sh"  # is sourced again and the guard established
+#    sourceOnce "foo.sh"    # creates a variable named foo__sh which acts as guard and sources foo.sh
+#    sourceOnce "foo.sh"    # will source nothing as foo__sh is already defined
+#    unset foo__sh          # unsets the guard
+#    sourceOnce "foo.sh"    # is sourced again and the guard established
+#
+#
 #
 #    # creates a variable named bar__foo__sh which acts as guard and sources bar/foo.sh
 #    sourceOnce "bar/foo.sh"
@@ -47,7 +49,7 @@ function sourceOnce() {
 	fi
 
 	local guard
-	guard=$(echo "$1" | perl -0777 -pe "s@(?:.*/([^/]+)/)?([^/]+)\$@\$1__\$2@;" -pe "s/[-.]/_/g")
+	guard=$(readlink -m "$1" | perl -0777 -pe "s@(?:.*/([^/]+)/)?([^/]+)\$@\$1__\$2@;" -pe "s/[-.]/_/g")
 
 	if ! [[ -v "$guard" ]]; then
 		printf -v "$guard" "%s" "true"

--- a/src/utility/update-bash-docu.sh
+++ b/src/utility/update-bash-docu.sh
@@ -38,10 +38,8 @@
 set -eu
 
 if ! [[ -v dir_of_tegonal_scripts ]]; then
-	declare dir_of_tegonal_scripts
 	dir_of_tegonal_scripts="$(realpath "$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)/..")"
-	declare -r dir_of_tegonal_scripts
-	source "$dir_of_tegonal_scripts/utility/source-once.sh"
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 sourceOnce "$dir_of_tegonal_scripts/utility/parse-fn-args.sh"
 sourceOnce "$dir_of_tegonal_scripts/utility/replace-snippet.sh"


### PR DESCRIPTION
The advantage of a setup script is backward compatibility. We might
want to do more initialisation in there in the future (e.g. provide
a flag that all functions should be readonly).
If we move this into the setup.sh then we can change it in the future
without the consumers needing to change their source code.



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/tegonal/scripts/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
