### PR TITLE
fix ignoring value in parse-args could be there is none

### DIFF
--- a/src/utility/parse-args.sh
+++ b/src/utility/parse-args.sh
@@ -209,7 +209,7 @@ function parseArguments {
 		done
 
 		if ((parseArguments_expectedName == 0)); then
-			if [[ $parseArguments_argName =~ ^- ]]; then
+			if [[ $parseArguments_argName =~ ^- ]] && (($# > 1)); then
 				logWarning "ignored argument \033[1;36m%s\033[0m (and its value %s)" "$parseArguments_argName" "$2"
 				shift
 			else


### PR DESCRIPTION
even if the argument starts with -



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/tegonal/scripts/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
