### PR TITLE
shift file name in sourceOnce as it is propagated to sourced file...

### DIFF
--- a/src/utility/source-once.sh
+++ b/src/utility/source-once.sh
@@ -58,6 +58,7 @@ function sourceOnce() {
 	fi
 
 	local -r sourceOnce_file="$1"
+	shift
 
 	local sourceOnce_guard
 	sourceOnce_guard=$(set -e && determineSourceOnceGuard "$sourceOnce_file")
@@ -75,7 +76,7 @@ function sourceOnce() {
 		# shellcheck disable=SC2034
 		declare __SOURCED__=true
 		# shellcheck disable=SC1090
-		source "$@"
+		source "$sourceOnce_file" "$@"
 		unset __SOURCED__
 	fi
 }


### PR DESCRIPTION
... in case there are no other args passed. This is because we source
inside a function and it looks like $@ is not re-declared for a sourced
function if no argument is passed



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/tegonal/scripts/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
