### PR TITLE
check that passed paths to runShellcheck can be used in find

### DIFF
--- a/src/qa/run-shellcheck.sh
+++ b/src/qa/run-shellcheck.sh
@@ -9,8 +9,8 @@
 #
 #######  Description  #############
 #
-#  function which searches for *.sh files within defined directories and runs shellcheck on each file with
-#  predefined settings i.a. sets `-s bash`
+#  function which searches for *.sh files within defined paths (directories or a single *.sh) and
+#  runs shellcheck on each file with predefined settings i.a. sets `-s bash`
 #
 #######  Usage  ###################
 #
@@ -47,24 +47,30 @@ sourceOnce "$dir_of_tegonal_scripts/utility/recursive-declare-p.sh"
 function runShellcheck() {
 	if ! (($# == 2)); then
 		logError "Two parameters need to be passed to runShellcheck, given \033[0;36m%s\033[0m\nFollowing a description of the parameters:" "$#"
-		echo >&2 '1: dirs         name of array which contains directories in which *.sh files are searched'
+		echo >&2 '1: dirs         name of array which contains paths in which *.sh files are searched'
 		echo >&2 '2: sourcePath   equivalent to shellcheck''s -P, path to search for sourced files, separated by :'
 		printStackTrace
 		exit 9
 	fi
-	local -rn directories=$1
+	local -rn runShellcheck_paths=$1
 	local -r sourcePath=$2
 
-	checkArgIsArray directories 1
+	exitIfArgIsNotArray runShellcheck_paths 1
+
+	local path
+	for path in "${runShellcheck_paths[@]}"; do
+		if ! find "$path" -maxdepth 1 -path "$path" >/dev/null; then
+			die "cannot find in path %s, see above" "$path"
+		fi
+	done
 
 	local -i fileWithIssuesCounter=0
 	local -i fileCounter=0
 	local script
-	while read -r -d $'\0' script; do
+	if ! while read -r -d $'\0' script; do
 		((++fileCounter))
 		declare output
-
-		output=$(shellcheck -C -x -o all -P "$sourcePath" "$script" || true)
+		output=$(shellcheck -C -x -o all -P "$sourcePath" "$script" 2>&1 || true)
 		if ! [[ $output == "" ]]; then
 			printf "%s\n" "$output"
 			((++fileWithIssuesCounter))
@@ -75,14 +81,19 @@ function runShellcheck() {
 		fi
 		printf "."
 	done < <(
-		find "${directories[@]}" -name '*.sh' -print0 ||
+		find "${runShellcheck_paths[@]}" -name '*.sh' -print0 ||
 			# `while read` will fail because there is no \0
 			true
-	)
+	); then
+		printf "\n"
+		die "problem during while read or find, see above"
+	fi
 	printf "\n"
 
 	if ((fileWithIssuesCounter > 0)); then
 		die "found shellcheck issues in %s files" "$fileWithIssuesCounter"
+	elif ((fileCounter == 0)); then
+		die "looks suspicious, no files where analysed, watch out for errors above"
 	else
 		logSuccess "no shellcheck issues found, analysed %s files" "$fileCounter"
 	fi


### PR DESCRIPTION
moreover:
- die if 0 files have been analysed
- also track stderr of shellcheck and complain (could e.g. happen if
  shellcheck cannot open a file)
- rename directories which is specified via -n runShellcheck_paths to
  avoid name clashes



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/tegonal/scripts/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
