### PR TITLE
always exit if there are not enough args or input validation fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,8 +743,6 @@ sourceOnce "foo.sh"    # will source nothing as foo__sh is already defined
 unset foo__sh          # unsets the guard
 sourceOnce "foo.sh"    # is sourced again and the guard established
 
-
-
 # creates a variable named bar__foo__sh which acts as guard and sources bar/foo.sh
 sourceOnce "bar/foo.sh"
 
@@ -925,6 +923,7 @@ Utility function to find out the initial `declare` statement after following `de
 # shellcheck disable=SC2034
 set -euo pipefail
 shopt -s inherit_errexit
+
 # Assumes tegonal's scripts were fetched with gget - adjust location accordingly
 dir_of_tegonal_scripts="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" >/dev/null && pwd 2>/dev/null)/../lib/tegonal-scripts/src"
 source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"

--- a/scripts/check-in-bug-template.sh
+++ b/scripts/check-in-bug-template.sh
@@ -41,7 +41,7 @@ function checkInBugTemplate() {
 	if ! [[ $missingInBugTemplate == "" ]]; then
 		returnDying "you forgot to add the following files to %s:\n%s" "$bugReportPath" "$missingInBugTemplate"
 	else
-		logSuccess "all scripts are listed in the bug template: $?"
+		logSuccess "all scripts are listed in the bug template"
 	fi
 }
 

--- a/spec/utility/parse-args_spec.sh
+++ b/spec/utility/parse-args_spec.sh
@@ -51,7 +51,7 @@ Describe 'parse_arg.sh'
 						asdf -a ''
 					)
 					When call parseArguments params 'example' 'v1.0.0' -v v0.1.0
-					The status should be success
+					The status should be successful
 					The variable version should equal "v0.1.0"
 			End
 			It 'does not pollute parent "scope"'
@@ -79,7 +79,7 @@ Describe 'parse_arg.sh'
 			Describe 'wrong number in params'
 				It 'one leftover'
 					declare params=(version -v '' leftOver1)
-					When call parseArguments params '' 'v1.0.0'--help
+					When run parseArguments params '' 'v1.0.0'--help
 					The status should be failure
 					The stderr should include "$(printf "array \033[0;36mparams\033[0m with parameter definitions is broken")"
 					The stderr should include 'The array needs to contain parameter definitions'
@@ -88,7 +88,7 @@ Describe 'parse_arg.sh'
 				End
 				It 'two leftovers'
 					declare params=(version -v '' leftOver1 leftOver2)
-					When call parseArguments params '' 'v1.0.0' --help
+					When run parseArguments params '' 'v1.0.0' --help
 					The status should be failure
 					The stderr should include "$(printf "array \033[0;36mparams\033[0m with parameter definitions is broken")"
 					The stderr should include 'leftOver1'
@@ -98,7 +98,7 @@ Describe 'parse_arg.sh'
 			It 'associative array passed'
 				# shellcheck disable=SC2034
 				declare -A associativeParams=([version]=-v)
-				When call parseArguments associativeParams '' 'v1.0.0' --help
+				When run parseArguments associativeParams '' 'v1.0.0' --help
 				The status should be failure
 				The stderr should include "$(printf "array \033[0;36massociativeParams\033[0m is broken")"
 				The stderr should include 'the first argument needs to be a non-associative array'
@@ -110,7 +110,7 @@ Describe 'parse_arg.sh'
 			Describe 'happy cases'
 				It 'complains if not all variables are set'
 					declare params=(version -v '')
-					When call checkAllArgumentsSet params '' 'v1.0.0'
+					When run checkAllArgumentsSet params '' 'v1.0.0'
 					The status should be failure
 					The stderr should include 'version not set'
 					The stderr should include 'Parameters:'
@@ -127,14 +127,14 @@ Describe 'parse_arg.sh'
 				Describe 'wrong number in params'
 					It 'one leftover'
 						declare params=(version -v '' leftOver1)
-						When call checkAllArgumentsSet params '' 'v1.0.0'
+						When run checkAllArgumentsSet params '' 'v1.0.0'
 						The status should be failure
 						The stderr should include 'leftOver1'
 					End
 					It 'two leftovers'
 						# shellcheck disable=SC2034
 						declare params=(version -v '' leftOver1 leftOver2)
-						When call checkAllArgumentsSet params '' 'v1.0.0'
+						When run checkAllArgumentsSet params '' 'v1.0.0'
 						The status should be failure
 						The stderr should include 'leftOver1'
 						The stderr should include 'leftOver2'

--- a/src/releasing/prepare-files-next-dev-cycle.sh
+++ b/src/releasing/prepare-files-next-dev-cycle.sh
@@ -75,7 +75,7 @@ function prepareFilesNextDevCycle() {
 	checkAllArgumentsSet params "" "$TEGONAL_SCRIPTS_VERSION"
 
 	if ! [[ "$version" =~ ^(v[0-9]+)\.([0-9]+)\.[0-9]+(-RC[0-9]+)?$ ]]; then
-		returnDying "version should match vX.Y.Z(-RC...), was %s" "$version"
+		die "version should match vX.Y.Z(-RC...), was %s" "$version"
 	fi
 
 	local -r projectsScriptsDir="$projectDir/scripts"

--- a/src/releasing/release-files.sh
+++ b/src/releasing/release-files.sh
@@ -105,10 +105,10 @@ function releaseFiles() {
 	checkAllArgumentsSet params "" "$TEGONAL_SCRIPTS_VERSION"
 
 	if ! [[ "$version" =~ $versionRegex ]]; then
-		returnDying "--version should match vX.Y.Z(-RC...), was %s" "$version"
+		die "--version should match vX.Y.Z(-RC...), was %s" "$version"
 	fi
 
-	checkArgIsFunction "$findForSigning" "--sign-fn"
+	exitIfArgIsNotFunction "$findForSigning" "--sign-fn"
 
 	if hasGitChanges; then
 		logError "you have uncommitted changes, please commit/stash first, following the output of git status:"

--- a/src/utility/ask.sh
+++ b/src/utility/ask.sh
@@ -56,7 +56,7 @@ function askYesOrNo() {
 	set -e
 	if ((lastResult > 128)); then
 		printf "\n"
-		logInfo "no user interaction after %s seconds, going to interpret that as a 'no'" "$timeout"
+		logInfo "no user interaction after %s seconds, going to interpret that as a 'no'." "$timeout"
 	fi
 	[[ $answer == y ]]
 }

--- a/src/utility/checks.sh
+++ b/src/utility/checks.sh
@@ -55,9 +55,17 @@ if ! [[ -v dir_of_tegonal_scripts ]]; then
 	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 sourceOnce "$dir_of_tegonal_scripts/utility/log.sh"
+sourceOnce "$dir_of_tegonal_scripts/utility/parse-fn-args.sh"
 sourceOnce "$dir_of_tegonal_scripts/utility/recursive-declare-p.sh"
 
 function checkArgIsArray() {
+	if ! (($# == 2)); then
+		logError "Two arguments needs to be passed to checkArgIsArray, given \033[0;36m%s\033[0m\n" "$#"
+		echo >&2 '1: array      name of the array to check'
+		echo >&2 '2: argNumber  what argument do we check (used in error message)'
+		printStackTrace
+		exit 9
+	fi
 	local -rn checkArgIsArray_arr=$1
 	local -r argNumber=$2
 	shift 2
@@ -78,9 +86,11 @@ function exitIfArgIsNotArray() {
 }
 
 function checkArgIsFunction() {
-	local -r name=$1
-	local -r argNumber=$2
-	shift 2
+	local name argNumber
+	# params is required for parseFnArgs thus:
+	# shellcheck disable=SC2034
+	local -ra params=(name argNumber)
+	parseFnArgs params "$@"
 
 	if ! declare -F "$name" >/dev/null; then
 		local declareP
@@ -97,6 +107,9 @@ function exitIfArgIsNotFunction() {
 }
 
 function checkCommandExists() {
+	if ! (($# == 1)); then
+		traceAndDie "you need to pass the name of the command to check to checkCommandExists"
+	fi
 	local -r name=$1
 	local file
 	file=$(command -v "$name") || return $?

--- a/src/utility/git-utils.sh
+++ b/src/utility/git-utils.sh
@@ -57,6 +57,7 @@ if ! [[ -v dir_of_tegonal_scripts ]]; then
 	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 fi
 sourceOnce "$dir_of_tegonal_scripts/utility/log.sh"
+sourceOnce "$dir_of_tegonal_scripts/utility/parse-fn-args.sh"
 
 function currentGitBranch() {
 	git rev-parse --abbrev-ref HEAD
@@ -69,9 +70,10 @@ function hasGitChanges() {
 }
 
 function countCommits() {
-	local -r from=$1
-	local -r to=$2
-	shift 2
+	local from to
+	# params is required for parseFnArgs thus:
+	# shellcheck disable=SC2034
+	local -ra params=(from to)
 	git rev-list --count "$from..$to" || die "could not count commits for $from..$to, see above"
 }
 

--- a/src/utility/gpg-utils.sh
+++ b/src/utility/gpg-utils.sh
@@ -47,19 +47,19 @@ sourceOnce "$dir_of_tegonal_scripts/utility/parse-fn-args.sh"
 
 function trustGpgKey() {
 	local gpgDir keyId
-	# params is required for parse-fn-args.sh thus:
+	# params is required for parseFnArgs thus:
 	# shellcheck disable=SC2034
 	local -ra params=(gpgDir keyId)
-	parseFnArgs params "$@" || return $?
+	parseFnArgs params "$@"
 	echo -e "5\ny\n" | gpg --homedir "$gpgDir" --command-fd 0 --edit-key "$keyId" trust
 }
 
 function importGpgKey() {
 	local gpgDir file withConfirmation
-	# params is required for parse-fn-args.sh thus:
+	# params is required for parseFnArgs thus:
 	# shellcheck disable=SC2034
 	local -ra params=(gpgDir file withConfirmation)
-	parseFnArgs params "$@" || exit $?
+	parseFnArgs params "$@"
 
 	local outputKey
 	outputKey=$(
@@ -84,7 +84,7 @@ function importGpgKey() {
 		echo "importing key $file"
 		gpg --homedir "$gpgDir" --import "$file"
 		local keyId
-		echo "$outputKey" | grep pub | perl -0777 -pe "s#pub\s+[^/]+/([0-9A-Z]+).*#\$1#g" |
+		grep pub <<< "$outputKey" | perl -0777 -pe "s#pub\s+[^/]+/([0-9A-Z]+).*#\$1#g" |
 			while read -r keyId; do
 				trustGpgKey "$gpgDir" "$keyId"
 			done

--- a/src/utility/io.sh
+++ b/src/utility/io.sh
@@ -51,7 +51,7 @@ function withCustomOutputInput() {
 	local fun=$3
 	shift 3
 
-	checkArgIsFunction "$fun" 3
+	exitIfArgIsNotFunction "$fun" 3
 
 	local tmpFile
 	tmpFile=$(mktemp /tmp/tegonal-scripts-io.XXXXXXXXX)

--- a/src/utility/parse-args.sh
+++ b/src/utility/parse-args.sh
@@ -98,33 +98,31 @@ function checkParameterDefinitionIsTriple() {
 		exit 9
 	fi
 
-	local -rn paramArr2=$1
-	local -r arrLength=${#paramArr2[@]}
+	local -rn checkParameterDefinitionIsTriple_paramArr=$1
+	local -r arrLength=${#checkParameterDefinitionIsTriple_paramArr[@]}
 
 	local arrayDefinition
-	arrayDefinition="$(
-		set -e
-		recursiveDeclareP paramArr2
-	)"
+	arrayDefinition=$(recursiveDeclareP checkParameterDefinitionIsTriple_paramArr) || die "could not get array definition of %s" "${!checkParameterDefinitionIsTriple_paramArr}"
 	reg='declare -a.*'
 	if ! [[ "$arrayDefinition" =~ $reg ]]; then
-		logError "the passed array \033[0;36m%s\033[0m is broken" "${!paramArr2}"
+		logError "the passed array \033[0;36m%s\033[0m is broken" "${!checkParameterDefinitionIsTriple_paramArr}"
 		echo >&2 "the first argument needs to be a non-associative array containing the parameter definitions, given:"
 		echo >&2 "$arrayDefinition"
 		echo >&2 ""
 		describeParameterTriple
 		printStackTrace
-		return 9
+		exit 9
 	fi
 
 	if ((arrLength == 0)); then
-		logError "the passed array \033[0;36m%s\033[0m with parameter definitions is broken, length was 0\033[0m" "${!paramArr2}"
+		logError "the passed array \033[0;36m%s\033[0m with parameter definitions is broken, length was 0\033[0m" "${!checkParameterDefinitionIsTriple_paramArr}"
 		describeParameterTriple
 		printStackTrace
+		exit 9
 	fi
 
 	if ! ((arrLength % 3 == 0)); then
-		logError "the passed array \033[0;36m%s\033[0m with parameter definitions is broken" "${!paramArr2}"
+		logError "the passed array \033[0;36m%s\033[0m with parameter definitions is broken" "${!checkParameterDefinitionIsTriple_paramArr}"
 		describeParameterTriple
 		echo >&2 ""
 		echo >&2 "given:"
@@ -134,17 +132,17 @@ function checkParameterDefinitionIsTriple() {
 
 		for ((i = 0; i < arrLength; i += 3)); do
 			if ((i + 2 < arrLength)); then
-				printf >&2 '"%s" "%s" "%s"\n' "${paramArr2[$i]}" "${paramArr2[$i + 1]}" "${paramArr2[$i + 2]}"
+				printf >&2 '"%s" "%s" "%s"\n' "${checkParameterDefinitionIsTriple_paramArr[$i]}" "${checkParameterDefinitionIsTriple_paramArr[$i + 1]}" "${checkParameterDefinitionIsTriple_paramArr[$i + 2]}"
 			else
 				printf >&2 "\033[1;33mleftovers:\033[0m\n"
-				printf >&2 '"%s"' "${paramArr2[$i]}"
+				printf >&2 '"%s"' "${checkParameterDefinitionIsTriple_paramArr[$i]}"
 				if ((i + 1 < arrLength)); then
-					printf >&2 ' "%s"' "${paramArr2[$i + 1]}"
+					printf >&2 ' "%s"' "${checkParameterDefinitionIsTriple_paramArr[$i + 1]}"
 				fi
 			fi
 		done
 		printStackTrace
-		return 9
+		exit 9
 	fi
 }
 
@@ -159,16 +157,14 @@ function parseArguments {
 		exit 9
 	fi
 
-	local -rn parseArguments_paramArr1=$1
+	local -rn parseArguments_paramArr=$1
 	local -r parseArguments_examples=$2
 	local -r parseArguments_version=$3
 	shift 3
 
-	# we want to be sure that we return at this point even if someone has `set +e` thus the or clause
-	# shellcheck disable=SC2310
-	checkParameterDefinitionIsTriple parseArguments_paramArr1 || return $?
+	checkParameterDefinitionIsTriple parseArguments_paramArr
 
-	local -r parseArguments_arrLength="${#parseArguments_paramArr1[@]}"
+	local -r parseArguments_arrLength="${#parseArguments_paramArr[@]}"
 
 	local -i parseArguments_numOfArgumentsParsed=0
 	while (($# > 0)); do
@@ -177,7 +173,7 @@ function parseArguments {
 			if ! ((parseArguments_numOfArgumentsParsed == 0)); then
 				logWarning "there were arguments defined prior to --help, they will all be ignored and instead printHelp will be called"
 			fi
-			printHelp parseArguments_paramArr1 "$parseArguments_examples" "$parseArguments_version"
+			printHelp parseArguments_paramArr "$parseArguments_examples" "$parseArguments_version"
 			return 99
 		fi
 		if [[ $parseArguments_argName == --version ]]; then
@@ -190,20 +186,20 @@ function parseArguments {
 
 		local -i parseArguments_expectedName=0
 		for ((parseArguments_i = 0; parseArguments_i < parseArguments_arrLength; parseArguments_i += 3)); do
-			local parseArguments_paramName="${parseArguments_paramArr1[parseArguments_i]}"
-			local parseArguments_pattern="${parseArguments_paramArr1[parseArguments_i + 1]}"
+			local parseArguments_paramName="${parseArguments_paramArr[parseArguments_i]}"
+			local parseArguments_pattern="${parseArguments_paramArr[parseArguments_i + 1]}"
 			local parseArguments_regex="^($parseArguments_pattern)$"
 			if [[ $parseArguments_argName =~ $parseArguments_regex ]]; then
 				if (($# < 2)); then
 					logError "no value defined for parameter \033[1;36m%s\033[0m (pattern %s) in %s" "$parseArguments_paramName" "$parseArguments_pattern" "${BASH_SOURCE[1]}"
 					echo >&2 "following the help documentation:"
 					echo >&2 ""
-					printHelp >&2 parseArguments_paramArr1 "$parseArguments_examples" "$parseArguments_version"
+					printHelp >&2 parseArguments_paramArr "$parseArguments_examples" "$parseArguments_version"
 					printStackTrace
-					return 1
+					exit 9
 				fi
 				# that's where the black magic happens, we are assigning to global variables here
-				printf -v "$parseArguments_paramName" "%s" "$2"
+				printf -v "$parseArguments_paramName" "%s" "$2" || die "could not assign value to $parseArguments_paramName"
 				parseArguments_expectedName=1
 				((++parseArguments_numOfArgumentsParsed))
 				shift
@@ -242,19 +238,17 @@ function printHelp {
 		printStackTrace
 		exit 9
 	fi
-	local -rn paramArr3=$1
+	local -rn printHelp_paramArr=$1
 	local -r examples=$2
 	local -r version=$3
 
-	# we want to be sure that we return at this point even if someone has `set +e` thus the or clause
-	# shellcheck disable=SC2310
-	checkParameterDefinitionIsTriple paramArr3 || return $?
+	checkParameterDefinitionIsTriple printHelp_paramArr
 
-	local arrLength="${#paramArr3[@]}"
+	local arrLength="${#printHelp_paramArr[@]}"
 
 	local maxLength=15
 	for ((i = 0; i < arrLength; i += 3)); do
-		local pattern="${paramArr3[i + 1]}"
+		local pattern="${printHelp_paramArr[i + 1]}"
 		local length=$((${#pattern} + 2))
 		if ((length > maxLength)); then
 			maxLength="$length"
@@ -263,8 +257,8 @@ function printHelp {
 
 	printf "\033[1;33mParameters:\033[0m\n"
 	for ((i = 0; i < arrLength; i += 3)); do
-		local pattern="${paramArr3[i + 1]}"
-		local help="${paramArr3[i + 2]}"
+		local pattern="${printHelp_paramArr[i + 1]}"
+		local help="${printHelp_paramArr[i + 2]}"
 
 		if [[ -n "$help" ]]; then
 			printf "%-${maxLength}s %s\n" "$pattern" "$help"
@@ -295,20 +289,20 @@ function checkAllArgumentsSet {
 	fi
 
 	# using unconventional naming in order to avoid name clashes with the variables we will check further below
-	local -rn checkAllArgumentsSet_paramArr4=$1
+	local -rn checkAllArgumentsSet_paramArr=$1
 	local -r checkAllArgumentsSet_examples=$2
 	local -r checkAllArgumentsSet_version=$3
 
-	# we want to be sure that we return at this point even if someone has `set +e` thus the or clause
-	# shellcheck disable=SC2310
-	checkParameterDefinitionIsTriple checkAllArgumentsSet_paramArr4 || return $?
+	checkParameterDefinitionIsTriple checkAllArgumentsSet_paramArr
 
-	local -r checkAllArgumentsSet_arrLength="${#checkAllArgumentsSet_paramArr4[@]}"
+	local -r checkAllArgumentsSet_arrLength="${#checkAllArgumentsSet_paramArr[@]}"
 	local -i checkAllArgumentsSet_good=1
 	for ((checkAllArgumentsSet_i = 0; checkAllArgumentsSet_i < checkAllArgumentsSet_arrLength; checkAllArgumentsSet_i += 3)); do
-		local checkAllArgumentsSet_paramName="${checkAllArgumentsSet_paramArr4[checkAllArgumentsSet_i]}"
-		local checkAllArgumentsSet_pattern="${checkAllArgumentsSet_paramArr4[checkAllArgumentsSet_i + 1]}"
-		if ! [[ -v "$checkAllArgumentsSet_paramName" ]]; then
+		local checkAllArgumentsSet_paramName="${checkAllArgumentsSet_paramArr[checkAllArgumentsSet_i]}"
+		local checkAllArgumentsSet_pattern="${checkAllArgumentsSet_paramArr[checkAllArgumentsSet_i + 1]}"
+		if [[ -v "$checkAllArgumentsSet_paramName" ]]; then
+			readonly "$checkAllArgumentsSet_paramName"
+		else
 			logError "%s not set via %s" "$checkAllArgumentsSet_paramName" "$checkAllArgumentsSet_pattern"
 			checkAllArgumentsSet_good=0
 		fi
@@ -317,11 +311,11 @@ function checkAllArgumentsSet {
 		echo >&2 ""
 		echo >&2 "following the help documentation:"
 		echo >&2 ""
-		printHelp >&2 checkAllArgumentsSet_paramArr4 "$checkAllArgumentsSet_examples" "$checkAllArgumentsSet_version"
+		printHelp >&2 checkAllArgumentsSet_paramArr "$checkAllArgumentsSet_examples" "$checkAllArgumentsSet_version"
 		if ((${#FUNCNAME} > 1)); then
 			# it is handy to see the stacktrace if it is not a direct call from command line
 			printStackTrace
 		fi
-		return 1
+		exit 1
 	fi
 }

--- a/src/utility/parse-fn-args.sh
+++ b/src/utility/parse-fn-args.sh
@@ -75,9 +75,9 @@ function parseFnArgs() {
 
 	# using unconventional naming in order to avoid name clashes with the variables we will initialise further below
 	local -rn parseFnArgs_paramArr1=$1
-	shift
+	shift 1
 
-	checkArgIsArray parseFnArgs_paramArr1 1
+	exitIfArgIsNotArray parseFnArgs_paramArr1 1
 
 	local parseFnArgs_withVarArgs
 	if [[ ${parseFnArgs_paramArr1[$((${#parseFnArgs_paramArr1[@]} - 1))]} == "varargs" ]]; then
@@ -112,7 +112,7 @@ function parseFnArgs() {
 			printf >&2 "%2s: %s\n" "$((parseFnArgs_i + 1))" "varargs"
 		fi
 		printStackTrace
-		return 9
+		exit 9
 	fi
 
 	if [[ $parseFnArgs_withVarArgs == false ]] && ! (($# == ${#parseFnArgs_paramArr1[@]})); then
@@ -125,13 +125,14 @@ function parseFnArgs() {
 			printf >&2 "%2s: %s\n" "$((parseFnArgs_i + 1))" "$parseFnArgs_name"
 		done
 		printStackTrace
-		return 9
+		exit 9
 	fi
 
 	for ((parseFnArgs_i = 0; parseFnArgs_i < minExpected; ++parseFnArgs_i)); do
 		local parseFnArgs_name=${parseFnArgs_paramArr1[parseFnArgs_i]}
 		# assign arguments to specified variables
-		printf -v "$parseFnArgs_name" "%s" "$1"
+		printf -v "$parseFnArgs_name" "%s" "$1" || die "could not assign value to $parseFnArgs_name"
+		local -r "$parseFnArgs_name"
 		shift
 	done
 
@@ -139,6 +140,6 @@ function parseFnArgs() {
 	if [[ $parseFnArgs_withVarArgs == true ]]; then
 		# is used afterwards
 		# shellcheck disable=SC2034
-		varargs=("$@")
+		varargs=("$@") || die "could not assign the rest of arguments to varargs"
 	fi
 }

--- a/src/utility/recursive-declare-p.doc.sh
+++ b/src/utility/recursive-declare-p.doc.sh
@@ -2,6 +2,7 @@
 # shellcheck disable=SC2034
 set -euo pipefail
 shopt -s inherit_errexit
+
 # Assumes tegonal's scripts were fetched with gget - adjust location accordingly
 dir_of_tegonal_scripts="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" >/dev/null && pwd 2>/dev/null)/../lib/tegonal-scripts/src"
 source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"

--- a/src/utility/recursive-declare-p.sh
+++ b/src/utility/recursive-declare-p.sh
@@ -19,6 +19,7 @@
 #    # shellcheck disable=SC2034
 #    set -euo pipefail
 #    shopt -s inherit_errexit
+#
 #    # Assumes tegonal's scripts were fetched with gget - adjust location accordingly
 #    dir_of_tegonal_scripts="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" >/dev/null && pwd 2>/dev/null)/../lib/tegonal-scripts/src"
 #    source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
@@ -54,10 +55,7 @@ sourceOnce "$dir_of_tegonal_scripts/utility/log.sh"
 
 function recursiveDeclareP() {
 	if ! (($# == 1)); then
-		logError "One parameter needs to be passed to recursiveDeclareP, given \033[0;36m%s\033[0m\nFollowing a description of the parameters:" "$#"
-		echo >&2 '1. variableName		 the name of the variable whose declaration statement shall be determined'
-		printStackTrace
-		exit 9
+		traceAndDie "you need to pass the variable name, whose declaration statement shall be determined, to recursiveDeclareP"
 	fi
 
 	definition=$(declare -p "$1")

--- a/src/utility/source-once.doc.sh
+++ b/src/utility/source-once.doc.sh
@@ -12,8 +12,6 @@ sourceOnce "foo.sh"    # will source nothing as foo__sh is already defined
 unset foo__sh          # unsets the guard
 sourceOnce "foo.sh"    # is sourced again and the guard established
 
-
-
 # creates a variable named bar__foo__sh which acts as guard and sources bar/foo.sh
 sourceOnce "bar/foo.sh"
 


### PR DESCRIPTION
moreover:
- make all parameter variables defined for parse-fn-args readonly
- make all parameter variables defined for parse-args in readonly
  in checkAllArgumentsSet
- prefix variables which are declared with -n with function name
  to avoid name clashes
- die if determineSourceOnceGuard fails
- die if sourcing file has errors



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/tegonal/scripts/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
