### PR TITLE
rename checkAllArgumentsSet to exitIfNotAllArgumentsSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,9 +567,9 @@ EOM
 )
 
 parseArguments params "$examples" "$@"
-# in case there are optional parameters, then fill them in here before calling checkAllArgumentsSet
+# in case there are optional parameters, then fill them in here before calling exitIfNotAllArgumentsSet
 if ! [[ -v directory ]]; then directory="."; fi
-checkAllArgumentsSet params "$examples"
+exitIfNotAllArgumentsSet params "$examples"
 
 # pass your variables storing the arguments to other scripts
 echo "p: $pattern, v: $version, d: $directory"

--- a/spec/utility/parse-args_spec.sh
+++ b/spec/utility/parse-args_spec.sh
@@ -106,11 +106,11 @@ Describe 'parse_arg.sh'
 		End
 	End
 
-	Describe 'checkAllArgumentsSet'
+	Describe 'exitIfNotAllArgumentsSet'
 			Describe 'happy cases'
 				It 'complains if not all variables are set'
 					declare params=(version -v '')
-					When run checkAllArgumentsSet params '' 'v1.0.0'
+					When run exitIfNotAllArgumentsSet params '' 'v1.0.0'
 					The status should be failure
 					The stderr should include 'version not set'
 					The stderr should include 'Parameters:'
@@ -120,21 +120,21 @@ Describe 'parse_arg.sh'
 			Describe 'errors'
 				It 'not enough arguments passed'
 					declare params=(version -v '')
-					When run checkAllArgumentsSet params
+					When run exitIfNotAllArgumentsSet params
 					The status should be failure
-					The stderr should include 'Three arguments need to be passed to checkAllArgumentsSet'
+					The stderr should include 'Three arguments need to be passed to exitIfNotAllArgumentsSet'
 				End
 				Describe 'wrong number in params'
 					It 'one leftover'
 						declare params=(version -v '' leftOver1)
-						When run checkAllArgumentsSet params '' 'v1.0.0'
+						When run exitIfNotAllArgumentsSet params '' 'v1.0.0'
 						The status should be failure
 						The stderr should include 'leftOver1'
 					End
 					It 'two leftovers'
 						# shellcheck disable=SC2034
 						declare params=(version -v '' leftOver1 leftOver2)
-						When run checkAllArgumentsSet params '' 'v1.0.0'
+						When run exitIfNotAllArgumentsSet params '' 'v1.0.0'
 						The status should be failure
 						The stderr should include 'leftOver1'
 						The stderr should include 'leftOver2'

--- a/src/releasing/prepare-files-next-dev-cycle.sh
+++ b/src/releasing/prepare-files-next-dev-cycle.sh
@@ -71,7 +71,7 @@ function prepareFilesNextDevCycle() {
 	parseArguments params "" "$TEGONAL_SCRIPTS_VERSION" "$@"
 	if ! [[ -v projectsRootDir ]]; then projectsRootDir=$(realpath "."); fi
 	if ! [[ -v additionalPattern ]]; then additionalPattern="^$"; fi
-	checkAllArgumentsSet params "" "$TEGONAL_SCRIPTS_VERSION"
+	exitIfNotAllArgumentsSet params "" "$TEGONAL_SCRIPTS_VERSION"
 
 	if ! [[ "$version" =~ ^(v[0-9]+)\.([0-9]+)\.[0-9]+(-RC[0-9]+)?$ ]]; then
 		die "version should match vX.Y.Z(-RC...), was %s" "$version"

--- a/src/releasing/release-files.sh
+++ b/src/releasing/release-files.sh
@@ -101,7 +101,7 @@ function releaseFiles() {
 	if ! [[ -v projectsRootDir ]]; then projectsRootDir=$(realpath "."); fi
 	if ! [[ -v additionalPattern ]]; then additionalPattern="^$"; fi
 	if ! [[ -v prepareOnly ]] || ! [[ "$prepareOnly" == "true" ]]; then prepareOnly=false; fi
-	checkAllArgumentsSet params "" "$TEGONAL_SCRIPTS_VERSION"
+	exitIfNotAllArgumentsSet params "" "$TEGONAL_SCRIPTS_VERSION"
 
 	if ! [[ "$version" =~ $versionRegex ]]; then
 		die "--version should match vX.Y.Z(-RC...), was %s" "$version"

--- a/src/releasing/sneak-peek-banner.sh
+++ b/src/releasing/sneak-peek-banner.sh
@@ -59,7 +59,7 @@ function sneakPeekBanner() {
 
 	parseArguments params "$examples" "$TEGONAL_SCRIPTS_VERSION" "$@"
 	if ! [[ -v file ]]; then file="./README.md"; fi
-	checkAllArgumentsSet params "$examples" "$TEGONAL_SCRIPTS_VERSION"
+	exitIfNotAllArgumentsSet params "$examples" "$TEGONAL_SCRIPTS_VERSION"
 
 	if [[ $command == show ]]; then
 		echo "show sneak peek banner in $file"

--- a/src/releasing/toggle-sections.sh
+++ b/src/releasing/toggle-sections.sh
@@ -63,7 +63,7 @@ function toggleSections() {
 
 	parseArguments params "$examples" "$TEGONAL_SCRIPTS_VERSION" "$@"
 	if ! [[ -v file ]]; then file="./README.md"; fi
-	checkAllArgumentsSet params "$examples" "$TEGONAL_SCRIPTS_VERSION"
+	exitIfNotAllArgumentsSet params "$examples" "$TEGONAL_SCRIPTS_VERSION"
 
 	function toggleSection() {
 		local file=$1

--- a/src/releasing/update-version-README.sh
+++ b/src/releasing/update-version-README.sh
@@ -65,7 +65,7 @@ function updateVersionReadme() {
 	parseArguments params "$examples" "$TEGONAL_SCRIPTS_VERSION" "$@"
 	if ! [[ -v file ]]; then file="./README.md"; fi
 	if ! [[ -v additionalPattern ]]; then additionalPattern=""; fi
-	checkAllArgumentsSet params "$examples" "$TEGONAL_SCRIPTS_VERSION"
+	exitIfNotAllArgumentsSet params "$examples" "$TEGONAL_SCRIPTS_VERSION"
 
 	echo "set version $version for Download badges and sneak peek banner in $file"
 

--- a/src/releasing/update-version-scripts.sh
+++ b/src/releasing/update-version-scripts.sh
@@ -65,7 +65,7 @@ function updateVersionScripts() {
 	parseArguments params "$examples" "$TEGONAL_SCRIPTS_VERSION" "$@"
 	if ! [[ -v directory ]]; then directory="./src"; fi
 	if ! [[ -v additionalPattern ]]; then additionalPattern=""; fi
-	checkAllArgumentsSet params "$examples" "$TEGONAL_SCRIPTS_VERSION"
+	exitIfNotAllArgumentsSet params "$examples" "$TEGONAL_SCRIPTS_VERSION"
 
 	echo "set version $version in bash headers in directory $directory"
 	if [[ -n $additionalPattern ]]; then

--- a/src/utility/parse-args.doc.sh
+++ b/src/utility/parse-args.doc.sh
@@ -32,9 +32,9 @@ EOM
 )
 
 parseArguments params "$examples" "$@"
-# in case there are optional parameters, then fill them in here before calling checkAllArgumentsSet
+# in case there are optional parameters, then fill them in here before calling exitIfNotAllArgumentsSet
 if ! [[ -v directory ]]; then directory="."; fi
-checkAllArgumentsSet params "$examples"
+exitIfNotAllArgumentsSet params "$examples"
 
 # pass your variables storing the arguments to other scripts
 echo "p: $pattern, v: $version, d: $directory"

--- a/src/utility/parse-args.sh
+++ b/src/utility/parse-args.sh
@@ -50,9 +50,9 @@
 #    )
 #
 #    parseArguments params "$examples" "$@"
-#    # in case there are optional parameters, then fill them in here before calling checkAllArgumentsSet
+#    # in case there are optional parameters, then fill them in here before calling exitIfNotAllArgumentsSet
 #    if ! [[ -v directory ]]; then directory="."; fi
-#    checkAllArgumentsSet params "$examples"
+#    exitIfNotAllArgumentsSet params "$examples"
 #
 #    # pass your variables storing the arguments to other scripts
 #    echo "p: $pattern, v: $version, d: $directory"
@@ -277,9 +277,9 @@ function printHelp {
 	printVersion "$version"
 }
 
-function checkAllArgumentsSet {
+function exitIfNotAllArgumentsSet {
 	if ! (($# == 3)); then
-		logError "Three arguments need to be passed to checkAllArgumentsSet, given \033[0;36m%s\033[0m\nFollowing a description of the parameters:" "$#"
+		logError "Three arguments need to be passed to exitIfNotAllArgumentsSet, given \033[0;36m%s\033[0m\nFollowing a description of the parameters:" "$#"
 		echo >&2 '1: params    the name of an array which contains the parameter definitions'
 		echo >&2 '2: examples  a string containing examples (or an empty string)'
 		echo >&2 '3: version    the version which shall be shown if one uses --version'
@@ -288,29 +288,29 @@ function checkAllArgumentsSet {
 	fi
 
 	# using unconventional naming in order to avoid name clashes with the variables we will check further below
-	local -rn checkAllArgumentsSet_paramArr=$1
-	local -r checkAllArgumentsSet_examples=$2
-	local -r checkAllArgumentsSet_version=$3
+	local -rn exitIfNotAllArgumentsSet_paramArr=$1
+	local -r exitIfNotAllArgumentsSet_examples=$2
+	local -r exitIfNotAllArgumentsSet_version=$3
 
-	checkParameterDefinitionIsTriple checkAllArgumentsSet_paramArr
+	checkParameterDefinitionIsTriple exitIfNotAllArgumentsSet_paramArr
 
-	local -r checkAllArgumentsSet_arrLength="${#checkAllArgumentsSet_paramArr[@]}"
-	local -i checkAllArgumentsSet_good=1
-	for ((checkAllArgumentsSet_i = 0; checkAllArgumentsSet_i < checkAllArgumentsSet_arrLength; checkAllArgumentsSet_i += 3)); do
-		local checkAllArgumentsSet_paramName="${checkAllArgumentsSet_paramArr[checkAllArgumentsSet_i]}"
-		local checkAllArgumentsSet_pattern="${checkAllArgumentsSet_paramArr[checkAllArgumentsSet_i + 1]}"
-		if [[ -v "$checkAllArgumentsSet_paramName" ]]; then
-			readonly "$checkAllArgumentsSet_paramName"
+	local -r exitIfNotAllArgumentsSet_arrLength="${#exitIfNotAllArgumentsSet_paramArr[@]}"
+	local -i exitIfNotAllArgumentsSet_good=1
+	for ((exitIfNotAllArgumentsSet_i = 0; exitIfNotAllArgumentsSet_i < exitIfNotAllArgumentsSet_arrLength; exitIfNotAllArgumentsSet_i += 3)); do
+		local exitIfNotAllArgumentsSet_paramName="${exitIfNotAllArgumentsSet_paramArr[exitIfNotAllArgumentsSet_i]}"
+		local exitIfNotAllArgumentsSet_pattern="${exitIfNotAllArgumentsSet_paramArr[exitIfNotAllArgumentsSet_i + 1]}"
+		if [[ -v "$exitIfNotAllArgumentsSet_paramName" ]]; then
+			readonly "$exitIfNotAllArgumentsSet_paramName"
 		else
-			logError "%s not set via %s" "$checkAllArgumentsSet_paramName" "$checkAllArgumentsSet_pattern"
-			checkAllArgumentsSet_good=0
+			logError "%s not set via %s" "$exitIfNotAllArgumentsSet_paramName" "$exitIfNotAllArgumentsSet_pattern"
+			exitIfNotAllArgumentsSet_good=0
 		fi
 	done
-	if ((checkAllArgumentsSet_good == 0)); then
+	if ((exitIfNotAllArgumentsSet_good == 0)); then
 		echo >&2 ""
 		echo >&2 "following the help documentation:"
 		echo >&2 ""
-		printHelp >&2 checkAllArgumentsSet_paramArr "$checkAllArgumentsSet_examples" "$checkAllArgumentsSet_version"
+		printHelp >&2 exitIfNotAllArgumentsSet_paramArr "$exitIfNotAllArgumentsSet_examples" "$exitIfNotAllArgumentsSet_version"
 		if ((${#FUNCNAME} > 1)); then
 			# it is handy to see the stacktrace if it is not a direct call from command line
 			printStackTrace


### PR DESCRIPTION
this way the side effect is clearer and aligns with the other
check.../exitIf... functions. Return non-zero in case of check and
exitIf exits. In this particular case I don't see value to add
checkAllArgumentsSet and one can use a sub-shell if really required



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/tegonal/scripts/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
