### PR TITLE
fix `no command passed to...` use BASH_SOURCE[1] and not 2

### DIFF
--- a/src/utility/parse-commands.sh
+++ b/src/utility/parse-commands.sh
@@ -115,7 +115,7 @@ function parseCommands {
 	shift 4 || die "could not shift by 4"
 
 	if (($# < 1 )); then
-		logError "no command passed to %s, following the output of --help" "$(basename "${BASH_SOURCE[2]}")"
+		logError "no command passed to %s, following the output of --help" "$(basename "${BASH_SOURCE[1]}")"
 		echo ""
 		parse_commands_printHelp parseCommands_paramArr "$version"
 		exit 9


### PR DESCRIPTION

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/tegonal/scripts/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
