### PR TITLE
use readlink -f instead of -m and fallback to realpath

### DIFF
--- a/src/utility/source-once.sh
+++ b/src/utility/source-once.sh
@@ -54,7 +54,7 @@ function determineSourceOnceGuard() {
 		traceAndDie "you need to pass the file name, for which we shall calculate the guard, to determineSourceOnceGuard"
 	fi
 	local -r file="$1"
-	readlink -m "$file" | perl -0777 -pe "s@(?:.*/([^/]+)/)?([^/]+)\$@sourceOnceGuard_\$1__\$2@;" -pe "s/[-.]/_/g" || die "was not able to determine sourceOnce guard for %s" "$file"
+	(readlink -f "$file" || realpath "$file") | perl -0777 -pe "s@(?:.*/([^/]+)/)?([^/]+)\$@sourceOnceGuard_\$1__\$2@;" -pe "s/[-.]/_/g" || die "was not able to determine sourceOnce guard for %s" "$file"
 }
 
 function sourceOnce_exitIfNotAtLeastOneArg() {


### PR DESCRIPTION
busybox does not support -m but we don't need it here as we usually want to calculate the guard for an existing path



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/gget/blob/v0.18.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
