### PR TITLE
use ENV for perl replace instead of own escaping

### DIFF
--- a/src/utility/gpg-utils.sh
+++ b/src/utility/gpg-utils.sh
@@ -31,8 +31,8 @@
 #    # import public-key.asc into gpg store located at .gt/.gpg and trust automatically
 #    importGpgKey .gt/.gpg ./public-key.asc --confirmation=false
 #
-#    # trust key which is identified via info.com in gpg store located at ~/.gpg
-#    trustGpgKey ~/.gpg info.com
+#    # trust key which is identified via info@tegonal.com in gpg store located at ~/.gpg
+#    trustGpgKey ~/.gpg info@tegonal.com
 #
 ###################################
 set -euo pipefail

--- a/src/utility/replace-help-snippet.sh
+++ b/src/utility/replace-help-snippet.sh
@@ -78,11 +78,11 @@ function replaceHelpSnippet() {
 	# shellcheck disable=SC2145		# we want array expansion in string
 	echo "capturing output of calling: $script ${varargs[@]}"
 
-	local snippet quotedSnippet markdownSnippet
+	local snippet cleanedUpSnippet markdownSnippet
 	snippet=$("$script" "${varargs[@]}") || true
 	# remove ansi colour codes form snippet
-	quotedSnippet=$(perl -0777 -pe "s/\033\[([01];\d{2}|0)m//g" <<<"$snippet") || die "could not quote snippet for %s" "$script"
-	markdownSnippet=$(printf "\`\`\`text\n%s\n\`\`\`" "$quotedSnippet") || die "could not create markdownSnippet for %s" "$script"
+	cleanedUpSnippet=$(perl -0777 -pe "s/\033\[([01];\d{2}|0)m//g" <<<"$snippet") || die "could not quote snippet for %s" "$script"
+	markdownSnippet=$(printf "\`\`\`text\n%s\n\`\`\`" "$cleanedUpSnippet") || die "could not create markdownSnippet for %s" "$script"
 
 	replaceSnippet "$script" "$id" "$dir" "$pattern" "$markdownSnippet"
 }

--- a/src/utility/replace-snippet.sh
+++ b/src/utility/replace-snippet.sh
@@ -63,12 +63,9 @@ function replaceSnippet() {
 	local -ra params=(file id dir pattern snippet)
 	parseFnArgs params "$@"
 
-	local quotedSnippet
-	quotedSnippet=$(perl -0777 -pe 's/(@|\$|\\)/\\$1/g;' <<< "$snippet" ) || die "could not quote snippet for file \033[1;36m%s\033[0m and id %s" "$file" "$id"
-
 	find "$dir" -name "$pattern" \
 		-exec echo "updating $id in {} " \; \
-		-exec perl -0777 -i \
-		-pe "s@<${id}>[\S\s]+</${id}>@<${id}>\n\n<!-- auto-generated, do not modify here but in $(realpath --relative-to "$PWD" "$file") -->\n$quotedSnippet\n\n</${id}>@g;" \
+		-exec SNIPPET="$snippet" perl -0777 -i \
+		-pe "s@<${id}>[\S\s]+</${id}>@<${id}>\n\n<!-- auto-generated, do not modify here but in $(realpath --relative-to "$PWD" "$file") -->\n\$ENV{SNIPPET}\n\n</${id}>@g;" \
 		{} \; 2>/dev/null || true
 }

--- a/src/utility/update-bash-docu.sh
+++ b/src/utility/update-bash-docu.sh
@@ -58,12 +58,13 @@ function updateBashDocumentation() {
 	pathWithoutExtension=${script::-3} || die "could not determine path without extension for script %s and %id" "$script" "$id"
 	snippet=$(cat "${pathWithoutExtension}.doc.sh") || die "could not cat %s" "${pathWithoutExtension}.doc.sh"
 
-	local quotedSnippet markdownSnippet
-	quotedSnippet=$(perl -0777 -pe 's/(\/|\$|\\)/\\$1/g;' <<<"$snippet" | sed 's/^/#    /' | sed 's/^#    $/#/') || die "was not able to quote the snippet for script %s and id %s" "$script" "$id"
+	local bashDocumentation markdownSnippet
+	# shellcheck disable=SC2001		# we want to add something to each new line and need two replacements, don't think this is possible with substitution
+	bashDocumentation=$(sed 's/^/#    /' <<<"$snippet" | sed 's/^#    $/#/') || die "was not able to quote the snippet for script %s and id %s" "$script" "$id"
 	markdownSnippet=$(printf "\`\`\`bash\n%s\n\`\`\`" "$snippet") || die "could not create the markdownSnippet for script %s and id %s" "$script" "$id"
 
-	perl -0777 -i \
-		-pe "s/(###+\s+Usage\s+###+\n#\n)[\S\s]+?(\n#\n###+)/\$1${quotedSnippet}\$2/g;" \
+	SNIPPET="$bashDocumentation" perl -0777 -i \
+		-pe 's/(###+\s+Usage\s+###+\n#\n)[\S\s]+?(\n#\n###+)/$1$ENV{SNIPPET}$2/g;' \
 		"$script" || die "could not replace the Usage section for %s" "$script"
 
 	replaceSnippet "$script.doc" "$id" "$dir" "$pattern" "$markdownSnippet"


### PR DESCRIPTION
- perl already implements escaping when using $ENV{}, use it instead of own implementation
- also escape snippet in update-bash-docu.sh



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/scripts/blob/v1.1.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
