### PR TITLE
split up release-files so that it can also be used for other processes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -24,11 +24,15 @@ body:
         - ci/jelastic/deploy.sh
         - ci/jelastic/utils.sh
         - qa/run-shellcheck.sh
+        - releasing/deduce-next-version.source.sh
         - releasing/pre-release-checks-git.sh
         - releasing/prepare-files-next-dev-cycle.sh
         - releasing/release-files.sh
+        - releasing/release-tag-prepare-next-push.sh
+        - releasing/shared-patterns.source.sh
         - releasing/sneak-peek-banner.sh
         - releasing/toggle-sections.sh
+        - releasing/update-version-common-steps.sh
         - releasing/update-version-README.sh
         - releasing/update-version-scripts.sh
         - releasing/update-version-issue-templates.sh

--- a/scripts/additional-release-files-preparations.sh
+++ b/scripts/additional-release-files-preparations.sh
@@ -45,14 +45,5 @@ function additionalReleasePrepareSteps() {
 	# same as in pull-hook.sh
 	local -r githubUrl="https://github.com/tegonal/scripts"
 	replaceTagInPullRequestTemplate "$projectDir/.github/PULL_REQUEST_TEMPLATE.md" "$githubUrl" "$version" || die "could not fill the placeholders in PULL_REQUEST_TEMPLATE.md"
-
-	updateVersionIssueTemplates -v "$version"
-
-	local -ra additionalScripts=(
-		"$projectDir/.gt/remotes/tegonal-gh-commons/pull-hook.sh"
-	)
-	for script in "${additionalScripts[@]}"; do
-		updateVersionScripts -v "$version" -p "$additionalPattern" -d "$script"
-	done
 }
 additionalReleasePrepareSteps

--- a/scripts/cleanup-on-push-to-main.sh
+++ b/scripts/cleanup-on-push-to-main.sh
@@ -34,6 +34,7 @@ function cleanupOnPushToMain() {
 	local script
 	find "$dir_of_tegonal_scripts" -name "*.sh" \
 		-not -name "*.doc.sh" \
+		-not -name "*.source.sh" \
 		-print0 |
 		while read -r -d $'\0' script; do
 			local relative
@@ -44,10 +45,13 @@ function cleanupOnPushToMain() {
 
 	local -ra scriptsWithHelp=(
 		ci/jelastic/deploy
+		releasing/pre-release-checks-git
 		releasing/prepare-files-next-dev-cycle
 		releasing/release-files
+		releasing/release-tag-prepare-next-push
 		releasing/sneak-peek-banner
 		releasing/toggle-sections
+		releasing/update-version-common-steps
 		releasing/update-version-README
 		releasing/update-version-scripts
 		releasing/update-version-issue-templates

--- a/src/releasing/deduce-next-version.source.sh
+++ b/src/releasing/deduce-next-version.source.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2168,SC2154
+#
+#    __                          __
+#   / /____ ___ ____  ___  ___ _/ /       This script is provided to you by https://github.com/tegonal/scripts
+#  / __/ -_) _ `/ _ \/ _ \/ _ `/ /        Copyright 2022 Tegonal Genossenschaft <info@tegonal.com>
+#  \__/\__/\_, /\___/_//_/\_,_/_/         It is licensed under Apache License 2.0
+#         /___/                           Please report bugs and contribute back your improvements
+#
+#                                         Version: v1.4.0-SNAPSHOT
+#######  Description  #############
+#
+#  intended to be sourced into a function which expects params version and nextVersion
+#	 Requires that $workingDirAbsolute is defined beforehand
+#
+###################################
+
+local -r versionRegex="$workingDirAbsolute/remotes"
+
+if [[ -v version ]]; then
+	if ! [[ -v nextVersion ]] && [[ "$version" =~ $versionRegex ]]; then
+		nextVersion="${BASH_REMATCH[1]}.$((BASH_REMATCH[2] + 1)).0"
+	else
+		logInfo "cannot deduce nextVersion from version as it does not follow format vX.Y.Z(-RC...): $version"
+	fi
+fi

--- a/src/releasing/pre-release-checks-git.doc.sh
+++ b/src/releasing/pre-release-checks-git.doc.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s inherit_errexit
+# Assumes tegonal's scripts were fetched with gt - adjust location accordingly
+dir_of_tegonal_scripts="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" >/dev/null && pwd 2>/dev/null)/../lib/tegonal-scripts/src"
+source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
+
+# checks releasing v0.1.0 makes sense and the current branch is main
+"$dir_of_tegonal_scripts/releasing/pre-release-checks-git.sh" -v v0.1.0
+
+# checks releasing v0.1.0 makes sense and the current branch is hotfix-1.0
+"$dir_of_tegonal_scripts/releasing/pre-release-checks-git.sh" -v v0.1.0 -b hotfix-1.0

--- a/src/releasing/pre-release-checks-git.sh
+++ b/src/releasing/pre-release-checks-git.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+#    __                          __
+#   / /____ ___ ____  ___  ___ _/ /       This script is provided to you by https://github.com/tegonal/scripts
+#  / __/ -_) _ `/ _ \/ _ \/ _ `/ /        Copyright 2022 Tegonal Genossenschaft <info@tegonal.com>
+#  \__/\__/\_, /\___/_//_/\_,_/_/         It is licensed under Apache License 2.0
+#         /___/                           Please report bugs and contribute back your improvements
+#
+#                                         Version: v1.4.0-SNAPSHOT
+#######  Description  #############
+#
+# Checks that releasing a certain version (creating a corresponding git tag) makes sense: We check:
+#  - the version follows the format vX.Y.Z(-RC...)
+#  - there are no uncommitted changes
+#  - checks current branch is `main` (we assume the convention that main is your default branch)
+#  - the desired version does not exist as tag locally or on remote
+#
+#######  Usage  ###################
+#
+#    #!/usr/bin/env bash
+#    set -euo pipefail
+#    shopt -s inherit_errexit
+#    # Assumes tegonal's scripts were fetched with gt - adjust location accordingly
+#    dir_of_tegonal_scripts="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" >/dev/null && pwd 2>/dev/null)/../lib/tegonal-scripts/src"
+#    source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
+#
+#    # checks releasing v0.1.0 makes sense and the current branch is main
+#    "$dir_of_tegonal_scripts/releasing/pre-release-checks-git.sh" -v v0.1.0
+#
+#    # checks releasing v0.1.0 makes sense and the current branch is hotfix-1.0
+#    "$dir_of_tegonal_scripts/releasing/pre-release-checks-git.sh" -v v0.1.0 -b hotfix-1.0
+#
+###################################
+set -euo pipefail
+shopt -s inherit_errexit
+unset CDPATH
+export TEGONAL_SCRIPTS_VERSION='v1.4.0-SNAPSHOT'
+
+if ! [[ -v dir_of_tegonal_scripts ]]; then
+	dir_of_tegonal_scripts="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" >/dev/null && pwd 2>/dev/null)/.."
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
+fi
+sourceOnce "$dir_of_tegonal_scripts/utility/git-utils.sh"
+sourceOnce "$dir_of_tegonal_scripts/utility/ask.sh"
+sourceOnce "$dir_of_tegonal_scripts/utility/parse-args.sh"
+
+function preReleaseCheckGit() {
+	source "$dir_of_tegonal_scripts/releasing/shared-patterns.source.sh" || die "could not source shared-patterns.source.sh"
+
+	local version branch
+	# shellcheck disable=SC2034   # is passed by name to parseArguments
+	local -ra params=(
+		version "$versionParamPattern" "$versionParamDocu"
+		branch "$branchParamPattern" "$branchParamDocu"
+	)
+
+	parseArguments params "" "$TEGONAL_SCRIPTS_VERSION" "$@"
+
+	local -r versionRegex="^(v[0-9]+)\.([0-9]+)\.[0-9]+(-RC[0-9]+)?$"
+	if ! [[ -v branch ]]; then branch="main"; fi
+	exitIfNotAllArgumentsSet params "" "$TEGONAL_SCRIPTS_VERSION"
+
+	if ! [[ "$version" =~ $versionRegex ]]; then
+		die "-v should match vX.Y.Z(-RC...), was %s" "$version"
+	fi
+
+	exitIfGitHasChanges
+
+	local tags
+	tags=$(git tag) || die "The following command failed (see above): git tag"
+	if grep "$version" <<< "$tags" >/dev/null; then
+		logError "tag %s already exists locally, adjust version or delete it with git tag -d %s" "$version" "$version"
+		if hasRemoteTag "$version"; then
+			printf >&2 "Note, it also exists on the remote which means you also need to delete it there -- e.g. via git push origin :%s\n" "$version"
+			exit 1
+		fi
+		logInfo "looks like the tag only exists locally."
+		if askYesOrNo "Shall I \`git tag -d %s\` and continue with the release?" "$version"; then
+			git tag -d "$version" || die "deleting tag %s failed" "$version"
+		else
+			exit 1
+		fi
+	fi
+
+	if hasRemoteTag "$version"; then
+		logError "tag %s already exists on remote origin, adjust version or delete it with git push origin :%s\n" "$version" "$version"
+		exit 1
+	fi
+
+	local currentBranch
+	currentBranch="$(currentGitBranch)" || die "could not determine current git branch, see above"
+	local -r currentBranch
+	if [[ $currentBranch != "$branch" ]]; then
+		logError "you need to be on the \033[0;36m%s\033[0m branch to release, check that you have merged all changes from your current branch \033[0;36m%s\033[0m." "$branch" "$currentBranch"
+		if askYesOrNo "Shall I switch to %s for you?" "$branch"; then
+			git checkout "$branch" || die "checking out branch \033[0;36m%s\033[0m failed" "$branch"
+		else
+			return 1
+		fi
+	fi
+
+	git fetch || die "could not fetch latest changes from origin, cannot verify if we are up-to-date with remote or not"
+
+	if localGitIsAhead "$branch"; then
+		logError "you are ahead of origin, please push first and check if CI succeeds before releasing. Following your additional changes:"
+		git -P log "origin/${branch}..$branch"
+		if askYesOrNo "Shall I git push for you?"; then
+			git push
+			logInfo "please check if your push passes CI and re-execute the release command afterwards"
+		fi
+		return 1
+	fi
+
+	while localGitIsBehind "$branch"; do
+		git fetch || die "could not fetch latest changes from origin, cannot verify if we are up-to-date with remote or not"
+		logError "you are behind of origin. I already fetched the changes for you, please check if you still want to release. Following the additional changes in origin/main:"
+		git -P log "${branch}..origin/$branch"
+		if askYesOrNo "Do you want to git pull?"; then
+			git pull || die "could not pull the changes, have to abort the release, please fix yourself and re-launch the release command"
+			if ! askYesOrNo "Do you want to release now?"; then
+				return 1
+			fi
+		else
+			return 1
+		fi
+	done
+}
+
+${__SOURCED__:+return}
+preReleaseCheckGit "$@"

--- a/src/releasing/release-files.sh
+++ b/src/releasing/release-files.sh
@@ -70,105 +70,44 @@ sourceOnce "$dir_of_tegonal_scripts/utility/git-utils.sh"
 sourceOnce "$dir_of_tegonal_scripts/utility/gpg-utils.sh"
 sourceOnce "$dir_of_tegonal_scripts/utility/ask.sh"
 sourceOnce "$dir_of_tegonal_scripts/utility/parse-args.sh"
+sourceOnce "$dir_of_tegonal_scripts/releasing/pre-release-checks-git.sh"
 sourceOnce "$dir_of_tegonal_scripts/releasing/sneak-peek-banner.sh"
 sourceOnce "$dir_of_tegonal_scripts/releasing/toggle-sections.sh"
-sourceOnce "$dir_of_tegonal_scripts/releasing/update-version-README.sh"
-sourceOnce "$dir_of_tegonal_scripts/releasing/update-version-scripts.sh"
+sourceOnce "$dir_of_tegonal_scripts/releasing/update-version-common-steps.sh"
 
 function releaseFiles() {
-	local version key findForSigning projectsRootDir additionalPattern nextVersion prepareOnly
+	local versionParamPatternLong branchParamPatternLong projectsRootDirParamPatternLong
+	local additionalPatternParamPatternLong nextVersionParamPatternLong prepareOnlyParamPatternLong
+	source "$dir_of_tegonal_scripts/releasing/shared-patterns.source.sh" || die "could not source shared-patterns.source.sh"
+
+	local version branch key findForSigning projectsRootDir additionalPattern nextVersion prepareOnly
 	# shellcheck disable=SC2034   # is passed by name to parseArguments
 	local -ra params=(
-		version '-v' "The version to release in the format vX.Y.Z(-RC...)"
-		key '-k|--key' 'The GPG private key which shall be used to sign the files'
-		findForSigning '--sign-fn' 'Function which is called to determine what files should be signed. It should be based find and allow to pass further arguments (we will i.a. pass -print0)'
-		projectsRootDir '--project-dir' '(optional) The projects directory -- default: .'
-		additionalPattern '-p|--pattern' '(optional) pattern which is used in a perl command (separator /) to search & replace additional occurrences. It should define two match groups and the replace operation looks as follows: '"\\\${1}\$version\\\${2}"
-		nextVersion '-nv|--next-version' '(optional) the version to use for prepare-next-dev-cycle -- default: is next minor based on version'
-		prepareOnly '--prepare-only' '(optional) defines whether the release shall only be prepared (i.e. no push, no tag, no prepare-next-dev-cycle) -- default: false'
+		version "$versionParamPattern" "$versionParamDocu"
+		key "$keyParamPattern" "$keyParamDocu"
+		findForSigning "$findForSigningParamPattern" "$findForSigningParamDocu"
+		branch "$branchParamPattern" "$branchParamDocu"
+		projectsRootDir "$projectsRootDirParamPattern" "$projectsRootDirParamDocu"
+		additionalPattern "$additionalPatternParamPattern" "$additionalPatternParamDocu"
+		nextVersion "$nextVersionParamPattern" "$nextVersionParamDocu"
+		prepareOnly "$prepareOnlyParamPattern" "$prepareOnlyParamDocu"
 	)
 
 	parseArguments params "" "$TEGONAL_SCRIPTS_VERSION" "$@"
 
-	local -r versionRegex="^(v[0-9]+)\.([0-9]+)\.[0-9]+(-RC[0-9]+)?$"
-
-	if [[ -v version ]]; then
-		if ! [[ -v nextVersion ]] && [[ "$version" =~ $versionRegex ]]; then
-			nextVersion="${BASH_REMATCH[1]}.$((BASH_REMATCH[2] + 1)).0"
-		else
-			logInfo "cannot deduce nextVersion from version as it does not follow format vX.Y.Z(-RC...): $version"
-		fi
-	fi
+	# deduces nextVersion based on version if not already set (and if version set)
+	source "$dir_of_tegonal_scripts/releasing/deduce-next-version.source.sh"
+	if ! [[ -v branch ]]; then branch="main"; fi
 	if ! [[ -v projectsRootDir ]]; then projectsRootDir=$(realpath "."); fi
 	if ! [[ -v additionalPattern ]]; then additionalPattern="^$"; fi
 	if ! [[ -v prepareOnly ]] || [[ $prepareOnly != "true" ]]; then prepareOnly=false; fi
 	exitIfNotAllArgumentsSet params "" "$TEGONAL_SCRIPTS_VERSION"
 
-	if ! [[ "$version" =~ $versionRegex ]]; then
-		die "--version should match vX.Y.Z(-RC...), was %s" "$version"
-	fi
-
 	exitIfArgIsNotFunction "$findForSigning" "--sign-fn"
-	exitIfGitHasChanges
 
-	local tags
-	tags=$(git tag) || die "The following command failed (see above): git tag"
-	if grep "$version" <<< "$tags" >/dev/null; then
-		logError "tag %s already exists locally, adjust version or delete it with git tag -d %s" "$version" "$version"
-		if hasRemoteTag "$version"; then
-			printf >&2 "Note, it also exists on the remote which means you also need to delete it there -- e.g. via git push origin :%s\n" "$version"
-			return 1
-		fi
-		logInfo "looks like the tag only exists locally."
-		if askYesOrNo "Shall I \`git tag -d %s\` and continue with the release?" "$version"; then
-			git tag -d "$version" || die "deleting tag %s failed" "$version"
-		else
-			return 1
-		fi
-	fi
-
-	if hasRemoteTag "$version"; then
-		logError "tag %s already exists on remote origin, adjust version or delete it with git push origin :%s\n" "$version" "$version"
-		return 1
-	fi
-
-	local branch
-	branch="$(currentGitBranch)" || die "could not determine current git branch, see above"
-	local -r expectedDefaultBranch="main" branch
-	if [[ $branch != "$expectedDefaultBranch" ]]; then
-		logError "you need to be on the \033[0;36m%s\033[0m branch to release, check that you have merged all changes from your current branch \033[0;36m%s\033[0m." "$expectedDefaultBranch" "$branch"
-		if askYesOrNo "Shall I switch to %s for you?" "$expectedDefaultBranch"; then
-			git checkout "$expectedDefaultBranch" || die "checking out branch %s failed" "$expectedDefaultBranch"
-		else
-			return 1
-		fi
-	fi
-
-	git fetch || die "could not fetch latest changes from origin"
-
-	if localGitIsAhead "$expectedDefaultBranch"; then
-		logError "you are ahead of origin, please push first and check if CI succeeds before releasing. Following your additional changes:"
-		git -P log origin/main..main
-		if askYesOrNo "Shall I git push for you?"; then
-			git push
-			logInfo "please check if your push passes CI and re-execute the release command afterwards"
-		fi
-		return 1
-	fi
-
-	while localGitIsBehind "$expectedDefaultBranch"; do
-		git fetch || die "could not fetch latest changes from origin"
-		logError "you are behind of origin. I already fetched the changes for you, please check if you still want to release. Following the additional changes in origin/main:"
-		git -P log "${expectedDefaultBranch}..origin/$expectedDefaultBranch"
-		if askYesOrNo "Do you want to git pull?"; then
-			git pull || die "could not pull the changes, have to abort the release, please fix yourself and re-launch the release command"
-			if ! askYesOrNo "Do you want to release now?"; then
-				return 1
-			fi
-		else
-			return 1
-		fi
-	done
+	preReleaseCheckGit \
+		"$versionParamPatternLong" "$version" \
+		"$branchParamPatternLong" "$branch"
 
 	local -r projectsScriptsDir="$projectsRootDir/scripts"
 	# shellcheck disable=SC2310			# we are aware of that || will disable set -e for sourceOnce
@@ -177,11 +116,11 @@ function releaseFiles() {
 	# make sure everything is up-to-date and works as it should
 	beforePr || return $?
 
-	sneakPeekBanner -c hide || return $?
-	toggleSections -c release || return $?
-	updateVersionReadme -v "$version" -p "$additionalPattern" || return $?
-	updateVersionScripts -v "$version" -p "$additionalPattern" || return $?
-	updateVersionScripts -v "$version" -p "$additionalPattern" -d "$projectsScriptsDir" || return $?
+	updateVersionCommonSteps \
+		"$versionParamPatternLong" "$version" \
+		"$projectsRootDirParamPatternLong" "$projectsRootDir" \
+		"$additionalPatternParamPatternLong" "$additionalPattern"
+
 	local -r additionalSteps="$projectsScriptsDir/additional-release-files-preparations.sh"
 	if [[ -f $additionalSteps ]]; then
 		logInfo "found $additionalSteps going to source it"
@@ -196,7 +135,7 @@ function releaseFiles() {
 	local -r gpgDir="$gtDir/gpg"
 	if ! rm -rf "$gpgDir"; then
 		logError "was not able to remove gpg directory %s\nPlease do this manually and re-run the release command" "$gpgDir"
-		git reset --hard "origin/$expectedDefaultBranch"
+		git reset --hard "origin/$branch"
 	fi
 	mkdir "$gpgDir"
 	chmod 700 "$gpgDir"
@@ -213,18 +152,14 @@ function releaseFiles() {
 		done || return $?
 
 	if [[ $prepareOnly != true ]]; then
-		git add . || return $?
-		git commit -m "$version" || return $?
-		git tag "$version" || return $?
-
-		# shellcheck disable=SC2310				# we are aware of that || will disable set -e for sourceOnce
-		sourceOnce "$projectsScriptsDir/prepare-next-dev-cycle.sh" || die "could not source prepare-next-dev-cycle.sh"
-		prepareNextDevCycle -v "$nextVersion" -p "$additionalPattern" || die "could not prepare next dev cycle for version %s" "$nextVersion"
-
-		git push origin "$version" || die "could not push tag to origin"
-		git push || die "could not push commits on %s to origin" "$expectedDefaultBranch"
+		releaseTagPushAndPrepareNext \
+			"$versionParamPatternLong" "$version" \
+			"$branchParamPatternLong" "$branch" \
+			"$projectsRootDirParamPatternLong" "$projectsRootDir" \
+			"$additionalPatternParamPatternLong" "$additionalPattern" \
+			"$nextVersionParamPatternLong" "$nextVersion"
 	else
-		printf "\033[1;33mskipping commit, creating tag and prepare-next-dev-cylce due to --prepare-only\033[0m\n"
+		printf "\033[1;33mskipping commit, creating tag and prepare-next-dev-cycle due to %s\033[0m\n" "$prepareOnlyParamPatternLong"
 	fi
 }
 

--- a/src/releasing/release-tag-prepare-next-push.doc.sh
+++ b/src/releasing/release-tag-prepare-next-push.doc.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s inherit_errexit
+# Assumes tegonal's scripts were fetched with gt - adjust location accordingly
+dir_of_tegonal_scripts="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" >/dev/null && pwd 2>/dev/null)/../lib/tegonal-scripts/src"
+source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
+
+# 1. git commit all changes and create a tag for v0.1.0
+# 2. call scripts/prepare-next-dev-cycle.sh with nextVersion deduced from the specified version (in this case 0.2.0-SNAPSHOT)
+# 3. git commit all changes as prepare v0.2.0 dev cycle
+# 4. push tag and commits
+"$dir_of_tegonal_scripts/releasing/release-tag-push-prepare-next.sh" -v v0.1.0
+
+# 1. searches for additional occurrences where the version should be replaced via the specified pattern
+# 2. git commit all changes and create a tag for v0.1.0
+# 3. call scripts/prepare-next-dev-cycle.sh with nextVersion deduced from the specified version (in this case 0.2.0-SNAPSHOT)
+# 4. git commit all changes as prepare v0.2.0 dev cycle
+# 4. push tag and commits
+"$dir_of_tegonal_scripts/releasing/release-tag-push-prepare-next.sh" \
+	-v v0.1.0 -k "0x945FE615904E5C85" \
+	-p "(TEGONAL_SCRIPTS_VERSION=['\"])[^'\"]+(['\"])"
+
+# in case you want to provide your own release.sh and only want to do some pre-configuration
+# then you might want to source it instead
+sourceOnce "$dir_of_tegonal_scripts/releasing/release-tag-push-prepare-next.sh"
+
+# and then call the function with your pre-configuration settings:
+# here we pre-define the additional pattern which shall be used in the search to replace the version
+# since "$@" follows afterwards, one could still override it via command line arguments.
+# put "$@" first, if you don't want that a user can override your pre-configuration
+releaseTagPushAndPrepareNext -p "(TEGONAL_SCRIPTS_VERSION=['\"])[^'\"]+(['\"])" "$@"

--- a/src/releasing/release-tag-prepare-next-push.sh
+++ b/src/releasing/release-tag-prepare-next-push.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+#    __                          __
+#   / /____ ___ ____  ___  ___ _/ /       This script is provided to you by https://github.com/tegonal/scripts
+#  / __/ -_) _ `/ _ \/ _ \/ _ `/ /        Copyright 2022 Tegonal Genossenschaft <info@tegonal.com>
+#  \__/\__/\_, /\___/_//_/\_,_/_/         It is licensed under Apache License 2.0
+#         /___/                           Please report bugs and contribute back your improvements
+#
+#                                         Version: v1.4.0-SNAPSHOT
+#######  Description  #############
+#
+#  Releasing files based on conventions:
+#  - expects a version in format vX.Y.Z(-RC...)
+#  - main is your default branch
+#  - requires you to have a /scripts folder in your project root which contains:
+#    - before-pr.sh which provides a parameterless function beforePr and can be sourced (add ${__SOURCED__:+return} before executing beforePr)
+#    - prepare-next-dev-cycle.sh which provides function prepareNextDevCycle and can be sourced
+#  - there is a public key defined at .gt/signing-key.public.asc which will be used
+#    to verify the signatures which will be created
+#
+#  You can define /scripts/additional-release-files-preparations.sh which is sourced (via sourceOnce) if it exists.
+#
+#######  Usage  ###################
+#
+#    #!/usr/bin/env bash
+#    set -euo pipefail
+#    shopt -s inherit_errexit
+#    # Assumes tegonal's scripts were fetched with gt - adjust location accordingly
+#    dir_of_tegonal_scripts="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" >/dev/null && pwd 2>/dev/null)/../lib/tegonal-scripts/src"
+#    source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
+#
+#    # 1. git commit all changes and create a tag for v0.1.0
+#    # 2. call scripts/prepare-next-dev-cycle.sh with nextVersion deduced from the specified version (in this case 0.2.0-SNAPSHOT)
+#    # 3. git commit all changes as prepare v0.2.0 dev cycle
+#    # 4. push tag and commits
+#    "$dir_of_tegonal_scripts/releasing/release-tag-push-prepare-next.sh" -v v0.1.0
+#
+#    # 1. searches for additional occurrences where the version should be replaced via the specified pattern
+#    # 2. git commit all changes and create a tag for v0.1.0
+#    # 3. call scripts/prepare-next-dev-cycle.sh with nextVersion deduced from the specified version (in this case 0.2.0-SNAPSHOT)
+#    # 4. git commit all changes as prepare v0.2.0 dev cycle
+#    # 4. push tag and commits
+#    "$dir_of_tegonal_scripts/releasing/release-tag-push-prepare-next.sh" \
+#    	-v v0.1.0 -k "0x945FE615904E5C85" \
+#    	-p "(TEGONAL_SCRIPTS_VERSION=['\"])[^'\"]+(['\"])"
+#
+#    # in case you want to provide your own release.sh and only want to do some pre-configuration
+#    # then you might want to source it instead
+#    sourceOnce "$dir_of_tegonal_scripts/releasing/release-tag-push-prepare-next.sh"
+#
+#    # and then call the function with your pre-configuration settings:
+#    # here we pre-define the additional pattern which shall be used in the search to replace the version
+#    # since "$@" follows afterwards, one could still override it via command line arguments.
+#    # put "$@" first, if you don't want that a user can override your pre-configuration
+#    releaseTagPushAndPrepareNext -p "(TEGONAL_SCRIPTS_VERSION=['\"])[^'\"]+(['\"])" "$@"
+#
+###################################
+set -euo pipefail
+shopt -s inherit_errexit
+unset CDPATH
+export TEGONAL_SCRIPTS_VERSION='v1.4.0-SNAPSHOT'
+
+if ! [[ -v dir_of_tegonal_scripts ]]; then
+	dir_of_tegonal_scripts="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" >/dev/null && pwd 2>/dev/null)/.."
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
+fi
+sourceOnce "$dir_of_tegonal_scripts/utility/git-utils.sh"
+sourceOnce "$dir_of_tegonal_scripts/utility/gpg-utils.sh"
+sourceOnce "$dir_of_tegonal_scripts/utility/ask.sh"
+sourceOnce "$dir_of_tegonal_scripts/utility/parse-args.sh"
+sourceOnce "$dir_of_tegonal_scripts/releasing/pre-release-checks-git.sh"
+sourceOnce "$dir_of_tegonal_scripts/releasing/sneak-peek-banner.sh"
+sourceOnce "$dir_of_tegonal_scripts/releasing/toggle-sections.sh"
+sourceOnce "$dir_of_tegonal_scripts/releasing/update-version-common-steps.sh"
+
+function releaseTagPushAndPrepareNext() {
+	source "$dir_of_tegonal_scripts/releasing/shared-patterns.source.sh" || die "could not source shared-patterns.source.sh"
+
+	local version branch projectsRootDir additionalPattern nextVersion
+	# shellcheck disable=SC2034   # is passed by name to parseArguments
+	local -ra params=(
+		version "$versionParamPattern" "$versionParamDocu"
+		branch "$branchParamPattern" "$branchParamDocu"
+		projectsRootDir "$projectsRootDirParamPattern" "$projectsRootDirParamDocu"
+		additionalPattern "$additionalPatternParamPattern" "$additionalPatternParamDocu"
+		nextVersion "$nextVersionParamPattern" "$nextVersionParamDocu"
+	)
+
+	parseArguments params "" "$TEGONAL_SCRIPTS_VERSION" "$@"
+
+	# deduces nextVersion based on version if not already set (and if version set)
+	source "$dir_of_tegonal_scripts/releasing/deduce-next-version.source.sh"
+	if ! [[ -v branch ]]; then branch="main"; fi
+	if ! [[ -v projectsRootDir ]]; then projectsRootDir=$(realpath "."); fi
+	if ! [[ -v additionalPattern ]]; then additionalPattern="^$"; fi
+	exitIfNotAllArgumentsSet params "" "$TEGONAL_SCRIPTS_VERSION"
+
+	git add . || return $?
+	git commit -m "$version" || return $?
+	git tag "$version" || return $?
+
+	local -r projectsScriptsDir="$projectsRootDir/scripts"
+
+	# shellcheck disable=SC2310				# we are aware of that || will disable set -e for sourceOnce
+	sourceOnce "$projectsScriptsDir/prepare-next-dev-cycle.sh" || die "could not source prepare-next-dev-cycle.sh"
+	prepareNextDevCycle -v "$nextVersion" -p "$additionalPattern" || die "could not prepare next dev cycle for version %s" "$nextVersion"
+
+	git push origin "$version" || die "could not push tag to origin"
+	git push || die "could not push commits on %s to origin" "$branch"
+}
+
+${__SOURCED__:+return}
+releaseTagPushAndPrepareNext "$@"

--- a/src/releasing/shared-patterns.source.sh
+++ b/src/releasing/shared-patterns.source.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034,SC2168
+#
+#    __                          __
+#   / /____ ___ ____  ___  ___ _/ /       This script is provided to you by https://github.com/tegonal/gt
+#  / __/ -_) _ `/ _ \/ _ \/ _ `/ /        Copyright 2022 Tegonal Genossenschaft <info@tegonal.com>
+#  \__/\__/\_, /\___/_//_/\_,_/_/         It is licensed under European Union Public License 1.2
+#         /___/                           Please report bugs and contribute back your improvements
+#                                         Version: v0.17.0-SNAPSHOT
+#######  Description  #############
+#
+#  constants intended to be sourced into a function
+#
+###################################
+
+local -r versionParamPatternLong='-v'
+local -r versionParamPattern="$versionParamPatternLong"
+local -r versionParamDocu='The version to release in the format vX.Y.Z(-RC...)'
+
+local -r keyParamPatternLong='key'
+local -r keyParamPattern="-k|$keyParamPatternLong"
+local -r keyParamDocu='The GPG private key which shall be used to sign the files'
+
+local -r findForSigningParamPatternLong='--sign-fn'
+local -r findForSigningParamPattern="$findForSigningParamPatternLong"
+local -r findForSigningParamDocu='Function which is called to determine what files should be signed. It should be based find and allow to pass further arguments (we will i.a. pass -print0)'
+
+local -r branchParamPatternLong='--branch'
+local -r branchParamPattern="-b|$branchParamPatternLong"
+local -r branchParamDocu='(optional) The expected branch which is currently checked out -- default: main'
+
+
+local -r projectsRootDirParamPatternLong='--project-dir'
+local -r projectsRootDirParamPattern="$projectsRootDirParamPatternLong"
+local -r projectsRootDirParamDocu='(optional) The projects directory -- default: .'
+
+local -r additionalPatternParamPatternLong='--pattern'
+local -r additionalPatternParamPattern="-p|$additionalPatternParamPatternLong"
+local -r additionalPatternParamDocu='(optional) pattern which is used in a perl command (separator /) to search & replace additional occurrences. It should define two match groups and the replace operation looks as follows: '"\\\${1}\$version\\\${2}"
+
+local -r nextVersionParamPatternLong='--next-version'
+local -r nextVersionParamPattern="-nv|$nextVersionParamPatternLong"
+local -r nextVersionParamDocu='(optional) the version to use for prepare-next-dev-cycle -- default: is next minor based on version'
+
+local -r prepareOnlyParamPatternLong='--prepare-only'
+local -r prepareOnlyParamPattern="$prepareOnlyParamPatternLong"
+local -r prepareOnlyParamDocu='(optional) defines whether the release shall only be prepared (i.e. no push, no tag, no prepare-next-dev-cycle) -- default: false'

--- a/src/releasing/update-version-README.sh
+++ b/src/releasing/update-version-README.sh
@@ -41,12 +41,14 @@ fi
 sourceOnce "$dir_of_tegonal_scripts/utility/parse-args.sh"
 
 function updateVersionReadme() {
+	source "$dir_of_tegonal_scripts/releasing/shared-patterns.source.sh" || die "could not source shared-patterns.source.sh"
+
 	local version file additionalPattern
 	# shellcheck disable=SC2034   # is passed by name to parseArguments
 	local -ra params=(
-		version '-v' 'the version which shall be used'
+		version "$versionParamPattern" "$versionParamDocu"
 		file '-f|--file' '(optional) the file where search & replace shall be done -- default: ./README.md'
-		additionalPattern '-p|--pattern' '(optional) pattern which is used in a perl command (separator /) to search & replace additional occurrences. It should define two match groups and the replace operation looks as follows: '"\\\${1}\$version\\\${2}"
+		additionalPattern "$additionalPatternParamPattern" "$additionalPatternParamDocu"
 	)
 	local -r examples=$(
 		# shellcheck disable=SC2312		# cat shouldn't fail for a constant string hence fine to ignore exit code

--- a/src/releasing/update-version-common-steps.doc.sh
+++ b/src/releasing/update-version-common-steps.doc.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s inherit_errexit
+# Assumes tegonal's scripts were fetched with gt - adjust location accordingly
+dir_of_tegonal_scripts="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" >/dev/null && pwd 2>/dev/null)/../lib/tegonal-scripts/src"
+source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
+
+# updates the version in headers of different files
+"$dir_of_tegonal_scripts/releasing/update-version-common-steps.sh" -v v0.1.0
+
+# 1. searches for additional occurrences where the version should be replaced via the specified pattern
+# 2. git commit all changes and create a tag for v0.1.0
+# 3. call scripts/prepare-next-dev-cycle.sh with nextVersion deduced from the specified version (in this case 0.2.0-SNAPSHOT)
+# 4. git commit all changes as prepare v0.2.0 dev cycle
+# 5. push tag and commits
+# 6. releases version v0.1.0 using the key 0x945FE615904E5C85 for signing and
+"$dir_of_tegonal_scripts/releasing/update-version-common-steps.sh" \
+	-v v0.1.0 -k "0x945FE615904E5C85" \
+	-p "(TEGONAL_SCRIPTS_VERSION=['\"])[^'\"]+(['\"])"
+
+# in case you want to provide your own release.sh and only want to do some pre-configuration
+# then you might want to source it instead
+sourceOnce "$dir_of_tegonal_scripts/releasing/update-version-common-steps.sh"
+
+# and then call the function with your pre-configuration settings:
+# here we pre-define the additional pattern which shall be used in the search to replace the version
+# since "$@" follows afterwards, one could still override it via command line arguments.
+# put "$@" first, if you don't want that a user can override your pre-configuration
+updateVersionCommonSteps -p "(TEGONAL_SCRIPTS_VERSION=['\"])[^'\"]+(['\"])" "$@"

--- a/src/releasing/update-version-common-steps.sh
+++ b/src/releasing/update-version-common-steps.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+#    __                          __
+#   / /____ ___ ____  ___  ___ _/ /       This script is provided to you by https://github.com/tegonal/scripts
+#  / __/ -_) _ `/ _ \/ _ \/ _ `/ /        Copyright 2022 Tegonal Genossenschaft <info@tegonal.com>
+#  \__/\__/\_, /\___/_//_/\_,_/_/         It is licensed under Apache License 2.0
+#         /___/                           Please report bugs and contribute back your improvements
+#
+#                                         Version: v1.4.0-SNAPSHOT
+#######  Description  #############
+#
+#  Releasing files based on conventions:
+#  - expects a version in format vX.Y.Z(-RC...)
+#  - main is your default branch
+#  - requires you to have a /scripts folder in your project root which contains:
+#    - before-pr.sh which provides a parameterless function beforePr and can be sourced (add ${__SOURCED__:+return} before executing beforePr)
+#    - prepare-next-dev-cycle.sh which provides function prepareNextDevCycle and can be sourced
+#  - there is a public key defined at .gt/signing-key.public.asc which will be used
+#    to verify the signatures which will be created
+#
+#  You can define /scripts/additional-release-files-preparations.sh which is sourced (via sourceOnce) if it exists.
+#
+#######  Usage  ###################
+#
+#    #!/usr/bin/env bash
+#    set -euo pipefail
+#    shopt -s inherit_errexit
+#    # Assumes tegonal's scripts were fetched with gt - adjust location accordingly
+#    dir_of_tegonal_scripts="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" >/dev/null && pwd 2>/dev/null)/../lib/tegonal-scripts/src"
+#    source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
+#
+#    # updates the version in headers of different files
+#    "$dir_of_tegonal_scripts/releasing/update-version-common-steps.sh" -v v0.1.0
+#
+#    # 1. searches for additional occurrences where the version should be replaced via the specified pattern
+#    # 2. git commit all changes and create a tag for v0.1.0
+#    # 3. call scripts/prepare-next-dev-cycle.sh with nextVersion deduced from the specified version (in this case 0.2.0-SNAPSHOT)
+#    # 4. git commit all changes as prepare v0.2.0 dev cycle
+#    # 5. push tag and commits
+#    # 6. releases version v0.1.0 using the key 0x945FE615904E5C85 for signing and
+#    "$dir_of_tegonal_scripts/releasing/update-version-common-steps.sh" \
+#    	-v v0.1.0 -k "0x945FE615904E5C85" \
+#    	-p "(TEGONAL_SCRIPTS_VERSION=['\"])[^'\"]+(['\"])"
+#
+#    # in case you want to provide your own release.sh and only want to do some pre-configuration
+#    # then you might want to source it instead
+#    sourceOnce "$dir_of_tegonal_scripts/releasing/update-version-common-steps.sh"
+#
+#    # and then call the function with your pre-configuration settings:
+#    # here we pre-define the additional pattern which shall be used in the search to replace the version
+#    # since "$@" follows afterwards, one could still override it via command line arguments.
+#    # put "$@" first, if you don't want that a user can override your pre-configuration
+#    updateVersionCommonSteps -p "(TEGONAL_SCRIPTS_VERSION=['\"])[^'\"]+(['\"])" "$@"
+#
+###################################
+set -euo pipefail
+shopt -s inherit_errexit
+unset CDPATH
+export TEGONAL_SCRIPTS_VERSION='v1.4.0-SNAPSHOT'
+
+if ! [[ -v dir_of_tegonal_scripts ]]; then
+	dir_of_tegonal_scripts="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" >/dev/null && pwd 2>/dev/null)/.."
+	source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
+fi
+sourceOnce "$dir_of_tegonal_scripts/utility/parse-args.sh"
+sourceOnce "$dir_of_tegonal_scripts/releasing/sneak-peek-banner.sh"
+sourceOnce "$dir_of_tegonal_scripts/releasing/toggle-sections.sh"
+sourceOnce "$dir_of_tegonal_scripts/releasing/update-version-issue-templates.sh"
+sourceOnce "$dir_of_tegonal_scripts/releasing/update-version-README.sh"
+sourceOnce "$dir_of_tegonal_scripts/releasing/update-version-scripts.sh"
+
+function updateVersionCommonSteps() {
+	local versionParamPatternLong additionalPatternParamPatternLong
+	source "$dir_of_tegonal_scripts/releasing/shared-patterns.source.sh" || die "could not source shared-patterns.source.sh"
+
+	local version projectsRootDir additionalPattern
+	# shellcheck disable=SC2034   # is passed by name to parseArguments
+	local -ra params=(
+		version "$versionParamPattern" "$versionParamDocu"
+		projectsRootDir "$projectsRootDirParamPattern" "$projectsRootDirParamDocu"
+		additionalPattern "$additionalPatternParamPattern" "$additionalPatternParamDocu"
+	)
+	parseArguments params "" "$TEGONAL_SCRIPTS_VERSION" "$@"
+
+	if ! [[ -v projectsRootDir ]]; then projectsRootDir=$(realpath "."); fi
+	if ! [[ -v additionalPattern ]]; then additionalPattern="^$"; fi
+	exitIfNotAllArgumentsSet params "" "$TEGONAL_SCRIPTS_VERSION"
+
+	local -r projectsScriptsDir="$projectsRootDir/scripts"
+
+	sneakPeekBanner -c hide || return $?
+	toggleSections -c release || return $?
+
+	updateVersionReadme "$versionParamPatternLong" "$version" \
+		"$additionalPatternParamPatternLong" "$additionalPattern" || return $?
+
+	updateVersionScripts "$versionParamPatternLong" "$version" \
+		"$additionalPatternParamPatternLong" "$additionalPattern" || return $?
+	updateVersionScripts "$versionParamPatternLong" "$version" \
+		"$additionalPatternParamPatternLong" "$additionalPattern" \
+		-d "$projectsScriptsDir" || return $?
+
+	find "$projectsRootDir/.gt" -name "pull-hook.sh" -print0 |
+		while read -r -d $'\0' script; do
+			updateVersionScripts "$versionParamPatternLong" "$version" \
+				"$additionalPatternParamPatternLong" "$additionalPattern" \
+				-d "$script"
+		done
+
+	local -r templateDir="$projectsRootDir/./.github/ISSUE_TEMPLATE"
+	if [[ -d "$templateDir" ]]; then
+		updateVersionIssueTemplates "$versionParamPatternLong" "$version" -d "$templateDir"
+	fi
+}
+
+${__SOURCED__:+return}
+updateVersionCommonSteps "$@"

--- a/src/releasing/update-version-issue-templates.sh
+++ b/src/releasing/update-version-issue-templates.sh
@@ -41,12 +41,14 @@ fi
 sourceOnce "$dir_of_tegonal_scripts/utility/parse-args.sh"
 
 function updateVersionIssueTemplates() {
+	source "$dir_of_tegonal_scripts/releasing/shared-patterns.source.sh" || die "could not source shared-patterns.source.sh"
+
 	local version directory additionalPattern
 	# shellcheck disable=SC2034   # is passed by name to parseArguments
 	local -ra params=(
-		version '-v' 'the version which shall be used'
+		version "$versionParamPattern" "$versionParamDocu"
 		directory '-d|--directory' '(optional) the working directory in which *.y(a)ml are searched (also in subdirectories) / you can also specify a file -- default: ./.github/ISSUE_TEMPLATE'
-		additionalPattern '-p|--pattern' '(optional) pattern which is used in a perl command (separator /) to search & replace additional occurrences. It should define two match groups and the replace operation looks as follows: '"\\\${1}\$version\\\${2}"
+		additionalPattern "$additionalPatternParamPattern" "$additionalPatternParamDocu"
 	)
 	local -r examples=$(
 		# shellcheck disable=SC2312		# cat shouldn't fail for a constant string hence fine to ignore exit code

--- a/src/releasing/update-version-scripts.sh
+++ b/src/releasing/update-version-scripts.sh
@@ -41,12 +41,14 @@ fi
 sourceOnce "$dir_of_tegonal_scripts/utility/parse-args.sh"
 
 function updateVersionScripts() {
+	source "$dir_of_tegonal_scripts/releasing/shared-patterns.source.sh" || die "could not source shared-patterns.source.sh"
+
 	local version directory additionalPattern
 	# shellcheck disable=SC2034   # is passed by name to parseArguments
 	local -ra params=(
-		version '-v' 'the version which shall be used'
+		version "$versionParamPattern" "$versionParamDocu"
 		directory '-d|--directory' '(optional) the working directory in which *.sh are searched (also in subdirectories) / you can also specify a file -- default: ./src'
-		additionalPattern '-p|--pattern' '(optional) pattern which is used in a perl command (separator /) to search & replace additional occurrences. It should define two match groups and the replace operation looks as follows: '"\\\${1}\$version\\\${2}"
+		additionalPattern "$additionalPatternParamPattern" "$additionalPatternParamDocu"
 	)
 	local -r examples=$(
 		# shellcheck disable=SC2312		# cat shouldn't fail for a constant string hence fine to ignore exit code

--- a/src/utility/parse-args.sh
+++ b/src/utility/parse-args.sh
@@ -103,22 +103,35 @@ function parse_args_exitIfParameterDefinitionIsNotTriple() {
 
 	exitIfArgIsNotArrayWithTuples "$1" 3 "parameter definitions" "first" "parse_args_describeParameterTriple"
 }
+function parseArgumentsIgnoreUnknown {
+	parseArgumentsInternal 'ignore' "$@"
+}
 
 function parseArguments {
-	if (($# < 3)); then
+	parseArgumentsInternal 'error' "$@"
+}
+
+function parseArgumentsInternal {
+	if (($# < 4)); then
 		logError "At least three arguments need to be passed to parseArguments, given \033[0;36m%s\033[0m\nFollowing a description of the parameters:" "$#"
-		echo >&2 '1: params     the name of an array which contains the parameter definitions'
-		echo >&2 '2: examples   a string containing examples (or an empty string)'
-		echo >&2 '3: version    the version which shall be shown if one uses --version'
-		echo >&2 '4... args...  the arguments as such, typically "$@"'
+		echo >&2 '1: unknownBehaviour   one of: error, ignore'
+		echo >&2 '2: params     				the name of an array which contains the parameter definitions'
+		echo >&2 '3: examples   				a string containing examples (or an empty string)'
+		echo >&2 '4: version    			 	the version which shall be shown if one uses --version'
+		echo >&2 '5... args...  				the arguments as such, typically "$@"'
 		printStackTrace
 		exit 9
 	fi
 
-	local -rn parseArguments_paramArr=$1
-	local -r parseArguments_examples=$2
-	local -r parseArguments_version=$3
-	shift 3 || die "could not shift by 3"
+	local -r parseArguments_unknownBehaviour=$1
+	local -rn parseArguments_paramArr=$2
+	local -r parseArguments_examples=$3
+	local -r parseArguments_version=$4
+	shift 4 || die "could not shift by 4"
+
+	if ! [[ "$parseArguments_unknownBehaviour" =~ ^(ignore|error)$ ]]; then
+		die "unknownBehaviour needs to be one of 'error' or 'ignore' got \033[0;36m%s\033[0m" "$parseArguments_unknownBehaviour"
+	fi
 
 	parse_args_exitIfParameterDefinitionIsNotTriple parseArguments_paramArr
 
@@ -140,7 +153,7 @@ function parseArguments {
 			if ! ((parseArguments_numOfArgumentsParsed == 0)); then
 				logWarning "there were arguments defined prior to --version, they will all be ignored and instead printVersion will be called"
 			fi
-			printVersion "$parseArguments_version"
+			printVersion "$parseArguments_version" 4
 			return 99
 		fi
 
@@ -167,12 +180,11 @@ function parseArguments {
 			fi
 		done
 
-		if ((parseArguments_expectedName == 0)); then
+		if [[ $parseArguments_unknownBehaviour = 'error' ]] && ((parseArguments_expectedName == 0)); then
 			if [[ $parseArguments_argName =~ ^- ]] && (($# > 1)); then
-				logWarning "ignored argument \033[1;36m%s\033[0m (and its value %s)" "$parseArguments_argName" "$2"
-				shift || die "could not shift by 1"
+				die "unknown argument \033[1;36m%s\033[0m (and value %s)" "$parseArguments_argName" "$2"
 			else
-				logWarning "ignored argument \033[1;36m%s\033[0m" "$parseArguments_argName"
+				die "unknown argument \033[1;36m%s\033[0m" "$parseArguments_argName"
 			fi
 		fi
 		shift || die "could not shift by 1"
@@ -222,7 +234,7 @@ function parse_args_printHelp {
 		echo "$examples"
 	fi
 	echo ""
-	printVersion "$version"
+	printVersion "$version" 4
 }
 
 function exitIfNotAllArgumentsSet {

--- a/src/utility/parse-utils.doc.sh
+++ b/src/utility/parse-utils.doc.sh
@@ -19,3 +19,9 @@ function myParseFunction() {
 		#...
 	done
 }
+
+function myVersionPrinter() {
+	# 3 defines that printVersion shall skip 3 stack frames to deduce the name of the script
+	# makes only sense if we already know that this method is called indirectly
+	printVersion "$MY_LIBRARY_VERSION" 3
+}

--- a/src/utility/parse-utils.sh
+++ b/src/utility/parse-utils.sh
@@ -38,6 +38,12 @@
 #    	done
 #    }
 #
+#    function myVersionPrinter() {
+#    	# 3 defines that printVersion shall skip 3 stack frames to deduce the name of the script
+#    	# makes only sense if we already know that this method is called indirectly
+#    	printVersion "$MY_LIBRARY_VERSION" 3
+#    }
+#
 #######	Limitations	#############
 #
 #	1. Does not support repeating arguments (last wins and overrides previous definitions)
@@ -56,12 +62,14 @@ if ! [[ -v dir_of_tegonal_scripts ]]; then
 fi
 
 function printVersion() {
-	if ! (($# == 1)); then
+	if ! (($# == 1)) && ! (($# == 2)); then
 		logError "One argument needs to be passed to printVersion, given \033[0;36m%s\033[0m\nFollowing a description of the parameters:" "$#"
-		echo >&2 '1: version   the version which shall be shown if one uses --version'
+		echo >&2 '1: version   		the version which shall be shown if one uses --version'
+		echo >&2 '1: stackFrame   numberthe version which shall be shown if one uses --version'
 		printStackTrace
 		exit 9
 	fi
 	local version=$1
-	logInfo "Version of %s is:\n%s" "$(basename "${BASH_SOURCE[3]:-${BASH_SOURCE[2]}}")" "$version"
+	local stackFrame=${2:-3}
+	logInfo "Version of %s is:\n%s" "$(basename "${BASH_SOURCE[stackFrame]:-${BASH_SOURCE[((stackFrame-1))]}}")" "$version"
 }


### PR DESCRIPTION
moreover:
- move updating the version in pull-hook.sh as well as github templates into the usual release process (i.e. not necessary to do it in additional-release-files-preparations.sh any more)



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/scripts/blob/v1.3.1/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
