### PR TITLE
ignoreUnknown in release-templates

### DIFF
--- a/scripts/prepare-next-dev-cycle.sh
+++ b/scripts/prepare-next-dev-cycle.sh
@@ -33,6 +33,8 @@ sourceOnce "$scriptsDir/before-pr.sh"
 function prepareNextDevCycle() {
 	source "$dir_of_tegonal_scripts/releasing/common-constants.source.sh" || die "could not source common-constants.source.sh"
 
+	# shellcheck disable=SC2034   # they seem unused but are necessary in order that parseArguments doesn't create global readonly vars
+	local version projectsRootDir additionalPattern
 	# shellcheck disable=SC2034   # is passed by name to parseArguments
 	local -ra params=(
 		version "$versionParamPattern" 'the version for which we prepare the dev cycle'

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -48,6 +48,8 @@ function release() {
 	source "$dir_of_tegonal_scripts/releasing/common-constants.source.sh" || die "could not source common-constants.source.sh"
 
 	local version
+  # shellcheck disable=SC2034   # they seem unused but are necessary in order that parseArguments doesn't create global readonly vars
+  local key branch nextVersion prepareOnly
 	# shellcheck disable=SC2034   # is passed by name to parseArguments
 	local -ra params=(
 		version "$versionParamPattern" "$versionParamDocu"

--- a/src/releasing/prepare-files-next-dev-cycle.sh
+++ b/src/releasing/prepare-files-next-dev-cycle.sh
@@ -75,7 +75,9 @@ function prepareFilesNextDevCycle() {
 	local additionalPatternParamPatternLong afterVersionUpdateHookParamPatternLong
 	source "$dir_of_tegonal_scripts/releasing/common-constants.source.sh" || die "could not source common-constants.source.sh"
 
-	local afterVersionUpdateHook
+	local version afterVersionUpdateHook projectsRootDir additionalPattern afterVersionUpdateHook
+	# shellcheck disable=SC2034   # they seem unused but are necessary in order that parseArguments doesn't create global readonly vars
+	local beforePrFn
 	# shellcheck disable=SC2034   # is passed by name to parseArguments
 	local -ra params=(
 		version "$versionParamPattern" 'the version for which we prepare the dev cycle'

--- a/src/releasing/prepare-next-dev-cycle-template.sh
+++ b/src/releasing/prepare-next-dev-cycle-template.sh
@@ -87,7 +87,7 @@ function prepareNextDevCycleTemplate() {
 		beforePrFn "$beforePrFnParamPattern" "$beforePrFnParamDocu"
 		afterVersionUpdateHook "$afterVersionUpdateHookParamPattern" "$afterVersionUpdateHookParamDocu"
 	)
-	parseArguments params "" "$TEGONAL_SCRIPTS_VERSION" "$@"
+	parseArgumentsIgnoreUnknown params "" "$TEGONAL_SCRIPTS_VERSION" "$@"
 	if ! [[ -v projectsRootDir ]]; then projectsRootDir=$(realpath ".") || die "could not determine realpath of ."; fi
 	if ! [[ -v additionalPattern ]]; then additionalPattern="^$"; fi
 	if ! [[ -v beforePrFn ]]; then beforePrFn="beforePr"; fi

--- a/src/releasing/release-files.sh
+++ b/src/releasing/release-files.sh
@@ -92,7 +92,9 @@ function releaseFiles() {
 	local additionalPatternParamPatternLong afterVersionUpdateHookParamPatternLong releaseHookParamPatternLong
 	source "$dir_of_tegonal_scripts/releasing/common-constants.source.sh" || die "could not source common-constants.source.sh"
 
-	local key findForSigning branch afterVersionUpdateHook
+	local version key findForSigning branch projectsRootDir additionalPattern afterVersionUpdateHook
+	# shellcheck disable=SC2034   # they seem unused but are necessary in order that parseArguments doesn't create global readonly vars
+	local nextVersion prepareOnly beforePrFn prepareNextDevCycle
 	# shellcheck disable=SC2034   # is passed by name to parseArguments
 	local -ra params=(
 		version "$versionParamPattern" "$versionParamDocu"

--- a/src/releasing/release-template.sh
+++ b/src/releasing/release-template.sh
@@ -114,7 +114,7 @@ function releaseTemplate() {
 		afterVersionUpdateHook "$afterVersionUpdateHookParamPattern" "$afterVersionUpdateHookParamDocu"
 	)
 
-	parseArguments params "" "$TEGONAL_SCRIPTS_VERSION" "$@"
+	parseArgumentsIgnoreUnknown params "" "$TEGONAL_SCRIPTS_VERSION" "$@"
 
 	# deduces nextVersion based on version if not already set (and if version set)
 	source "$dir_of_tegonal_scripts/releasing/deduce-next-version.source.sh"


### PR DESCRIPTION
moreover:
- always use `local` for vars parsed by parseArguments, otherwise parseArgs will create global readonly vars which can lead to problems



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/scripts/blob/v2.0.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
