### PR TITLE
introduce afterVersionHookParams so that it can be used in hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The scripts are ordered by topic:
 	- [Releasing Files](#release-files)
 	- [Prepare Files Next Dev Cycle](#prepare-files-next-dev-cycle)
 	- [Release Template](#release-template)
-    - [Prepare Next Dev Cycle Template]
+    - [Prepare Next Dev Cycle Template](#prepare-next-dev-cycle-template)
 	- [git Pre-Release checks](#git-pre-release-checks)
 	- [Update Version common steps](#update-version-common-release-steps)
 	- [Update Version in README](#update-version-in-readme)
@@ -621,7 +621,7 @@ releaseTemplate "$@" --release-hook releaseScalaLib \
 
 ## Prepare next dev cycle template
 
-
+template to prepare a next releases, updating version and such using [update-version-common-steps.sh](#update-version-common-release-steps)
 
 Help:
 
@@ -742,7 +742,7 @@ source "$dir_of_tegonal_scripts/setup.sh" "$dir_of_tegonal_scripts"
 
 </releasing-pre-release-checks-git>
 
-## Update Version Common Release Steps
+## Update Version Common Steps
 
 Performs several `releasing` scripts defined in the following sections:
 
@@ -751,8 +751,8 @@ Performs several `releasing` scripts defined in the following sections:
 - Updates the version in .github/ISSUE_TEMPLATE/**.y(a)ml files (
   see [Update Version in issue templates](#update-version-in-issue-templates))
 - Updates the version in the README.md (see next section [Update Version in README](#update-version-in-readme)).
-- [activates the release section](#toggle-mainrelease-sections)
-- [hides the sneak-peek banner](#hideshow-sneak-peek-banner)
+- [activates the release section and hides the main section](#toggle-mainrelease-sections) if `-for-release` is `true` (the opposite otherwise)
+- [hides the sneak-peek banner](#hideshow-sneak-peek-banner) (or shows it if `--for-release` is `false`)
 
 Help:
 

--- a/scripts/prepare-next-dev-cycle.sh
+++ b/scripts/prepare-next-dev-cycle.sh
@@ -40,6 +40,7 @@ function prepareNextDevCycle() {
 		version "$versionParamPattern" 'the version for which we prepare the dev cycle'
 		projectsRootDir "$projectsRootDirParamPattern" "$projectsRootDirParamDocu"
 		additionalPattern "$additionalPatternParamPattern" "is ignored as additional pattern is specified internally, still here as release-files uses this argument"
+		beforePrFn "$beforePrFnParamPattern" "$beforePrFnParamDocu"
 	)
 	parseArguments params "" "$TEGONAL_SCRIPTS_VERSION" "$@"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -48,8 +48,8 @@ function release() {
 	source "$dir_of_tegonal_scripts/releasing/common-constants.source.sh" || die "could not source common-constants.source.sh"
 
 	local version
-  # shellcheck disable=SC2034   # they seem unused but are necessary in order that parseArguments doesn't create global readonly vars
-  local key branch nextVersion prepareOnly
+	# shellcheck disable=SC2034   # they seem unused but are necessary in order that parseArguments doesn't create global readonly vars
+	local key branch nextVersion prepareOnly
 	# shellcheck disable=SC2034   # is passed by name to parseArguments
 	local -ra params=(
 		version "$versionParamPattern" "$versionParamDocu"
@@ -60,14 +60,20 @@ function release() {
 	)
 	parseArguments params "" "$TEGONAL_SCRIPTS_VERSION" "$@"
 
+	# we don't check if all args are set (and neither set default values) as we currently don't use
+	# any param in here but just delegate to releaseFiles.
+
 	function findScripts() {
 		find "$dir_of_tegonal_scripts" -name "*.sh" -not -name "*.doc.sh" "$@"
 	}
 
 	function release_afterVersionHook() {
+		local version projectsRootDir additionalPattern
+		parseArguments afterVersionHookParams "" "$TEGONAL_SCRIPTS_VERSION" "$@"
+
 		# same as in pull-hook.sh
 		local -r githubUrl="https://github.com/tegonal/scripts"
-		replaceTagInPullRequestTemplate "$projectDir/.github/PULL_REQUEST_TEMPLATE.md" "$githubUrl" "$version" || die "could not fill the placeholders in PULL_REQUEST_TEMPLATE.md"
+		replaceTagInPullRequestTemplate "$projectsRootDir/.github/PULL_REQUEST_TEMPLATE.md" "$githubUrl" "$version" || die "could not fill the placeholders in PULL_REQUEST_TEMPLATE.md"
 	}
 
 	# similar as in prepare-next-dev-cycle.sh, you might need to update it there as well if you change something here

--- a/src/releasing/common-constants.source.sh
+++ b/src/releasing/common-constants.source.sh
@@ -68,3 +68,9 @@ local -r afterVersionUpdateHookParamPatternLong='--after-version-update-hook'
 local -r afterVersionUpdateHookParamPattern="$afterVersionUpdateHookParamPatternLong"
 local -r afterVersionUpdateHookParamDocu="(optional) if defined, then this function is called after versions were updated and before calling beforePr. \
 The following arguments are passed: $versionParamPatternLong version $projectsRootDirParamPatternLong projectsRootDir and $additionalPatternParamPatternLong additionalPattern"
+
+local -ra afterVersionHookParams=(
+	version "$versionParamPattern" "$versionParamDocu"
+	projectsRootDir "$projectsRootDirParamPattern" "$projectsRootDirParamDocu"
+	additionalPattern "$additionalPatternParamPattern" "$additionalPatternParamDocu"
+)

--- a/src/releasing/prepare-files-next-dev-cycle.sh
+++ b/src/releasing/prepare-files-next-dev-cycle.sh
@@ -100,13 +100,7 @@ function prepareFilesNextDevCycle() {
 
 	function prepareFilesNextDevCycle_afterVersionHook() {
 		local version projectsRootDir additionalPattern
-		# shellcheck disable=SC2034   # is passed by name to parseArguments
-		local -ra params=(
-			version "$versionParamPattern" 'the version for which we prepare the dev cycle'
-			projectsRootDir "$projectsRootDirParamPattern" "$projectsRootDirParamDocu"
-			additionalPattern "$additionalPatternParamPattern" "$additionalPatternParamDocu"
-		)
-		parseArguments params "" "$TEGONAL_SCRIPTS_VERSION" "$@"
+		parseArguments afterVersionHookParams "" "$TEGONAL_SCRIPTS_VERSION" "$@"
 
 		updateVersionScripts \
 			"$versionParamPatternLong" "$version" \

--- a/src/releasing/release-files.sh
+++ b/src/releasing/release-files.sh
@@ -138,13 +138,7 @@ function releaseFiles() {
 
 	function releaseFiles_afterVersionHook() {
 		local version projectsRootDir additionalPattern
-		# shellcheck disable=SC2034   # is passed by name to parseArguments
-		local -ra params=(
-			version "$versionParamPattern" 'the version for which we prepare the dev cycle'
-			projectsRootDir "$projectsRootDirParamPattern" "$projectsRootDirParamDocu"
-			additionalPattern "$additionalPatternParamPattern" "$additionalPatternParamDocu"
-		)
-		parseArguments params "" "$TEGONAL_SCRIPTS_VERSION" "$@"
+		parseArguments afterVersionHookParams "" "$TEGONAL_SCRIPTS_VERSION" "$@"
 
 		updateVersionScripts \
 			"$versionParamPatternLong" "$version" \


### PR DESCRIPTION
moreover:
- fix prepare-next-dev-cycle should now also expect a param called --before-pr-fn param
- document prepare-next-dev-cycle-template in README.md
- fix documentation of update-version-common-steps also mention the case where someone chooses --for-release false



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/scripts/blob/v2.0.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
