### PR TITLE
allow to filter remote tags by extended regex (grep -E)

### DIFF
--- a/src/utility/git-utils.sh
+++ b/src/utility/git-utils.sh
@@ -3,7 +3,7 @@
 #    __                          __
 #   / /____ ___ ____  ___  ___ _/ /       This script is provided to you by https://github.com/tegonal/scripts
 #  / __/ -_) _ `/ _ \/ _ \/ _ `/ /        It is licensed under Apache License 2.0
-#  \__/\__/\_, /\___/_//_/\_,_/_/         Please remotert bugs and contribute back your improvements
+#  \__/\__/\_, /\___/_//_/\_,_/_/         Please report bugs and contribute back your improvements
 #         /___/
 #                                         Version: v3.3.0-SNAPSHOT
 #
@@ -147,13 +147,18 @@ function remoteTagsSorted() {
 }
 
 function latestRemoteTag() {
-	if (($# > 1)); then
-		traceAndDie "you can optionally pass the name of the remote (defaults to origin) to latestRemoteTag but not more, given: %s" "$#"
+	if (($# > 2)); then
+			logError "Maximum 2 arguments can be passed to latestRemoteTag, given \033[0;36m%s\033[0m\n" "$#"
+			echo >&2 '1: remote   	(optional) the name of the remote, defaults to origin'
+			echo >&2 '2: tagFilter	(optional) a regex pattern (as supported by grep -E) which allows to filter available tags before determining the latest, defaults to .* (i.e. include all)'
+			printStackTrace
+			exit 9
 	fi
 	local -r remote=${1:-"origin"}
+	local -r tagFilter=${2:-".*"}
 	local tag
 	#shellcheck disable=SC2310			# we are aware of that || will disable set -e for remoteTagsSorted
-	tag=$(remoteTagsSorted "$remote" | tail -n 1) || die "could not get remote tags sorted, see above"
+	tag=$(remoteTagsSorted "$remote" | grep -E "$tagFilter" | tail -n 1) || die "could not get remote tags sorted, see above"
 	if [[ -z $tag ]]; then
 		die "looks like remote \033[0;36m%s\033[0m does not have a tag yet." "$remote"
 	fi


### PR DESCRIPTION
This way one can define things like:
- return only major versions
- return only major or minor versions
- skip a certain version
- only tags with a certain prefix (e.g. for a mono-repo)
- and so on



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/scripts/blob/v3.2.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
