### PR TITLE
rename exitIfVariablesNotDefined to exitIfVariablesNotDeclared

### DIFF
--- a/README.md
+++ b/README.md
@@ -1387,7 +1387,7 @@ exitIfCommandDoesNotExist "git" "please install it via https://git-scm.com/downl
 exitIfVarsNotAlreadySetBySource myVar1 var2 var3
 
 declare myVar4
-exitIfVariablesNotDefined myVar4 myVar5 # would exit because myVar5 is not set
+exitIfVariablesNotDeclared myVar4 myVar5 # would exit because myVar5 is not set
 echo "myVar4 $myVar4"
 ```
 

--- a/src/utility/checks.doc.sh
+++ b/src/utility/checks.doc.sh
@@ -55,5 +55,5 @@ exitIfCommandDoesNotExist "git" "please install it via https://git-scm.com/downl
 exitIfVarsNotAlreadySetBySource myVar1 var2 var3
 
 declare myVar4
-exitIfVariablesNotDefined myVar4 myVar5 # would exit because myVar5 is not set
+exitIfVariablesNotDeclared myVar4 myVar5 # would exit because myVar5 is not set
 echo "myVar4 $myVar4"

--- a/src/utility/checks.sh
+++ b/src/utility/checks.sh
@@ -71,7 +71,7 @@
 #    exitIfVarsNotAlreadySetBySource myVar1 var2 var3
 #
 #    declare myVar4
-#    exitIfVariablesNotDefined myVar4 myVar5 # would exit because myVar5 is not set
+#    exitIfVariablesNotDeclared myVar4 myVar5 # would exit because myVar5 is not set
 #    echo "myVar4 $myVar4"
 #
 ###################################
@@ -300,7 +300,7 @@ function exitIfVarsNotAlreadySetBySource() {
 	done
 }
 
-function exitIfVariablesNotDefined() {
+function exitIfVariablesNotDeclared() {
 	shift 1 || traceAndDie "could not shift by 1"
 	for variableName in "$@"; do
 		if ! declare -p "$variableName" 2>/dev/null | grep -q 'declare --'; then

--- a/src/utility/parse-args.sh
+++ b/src/utility/parse-args.sh
@@ -135,10 +135,10 @@ function parseArgumentsInternal {
 
 	parse_args_exitIfParameterDefinitionIsNotTriple parseArguments_paramArr
 
-	# shellcheck disable=SC2034		# passed by name to exitIfVariablesNotDefined
+	# shellcheck disable=SC2034		# passed by name to exitIfVariablesNotDeclared
 	local -a parseArguments_variableNames
 	arrTakeEveryX parseArguments_paramArr parseArguments_variableNames 3 0
-	exitIfVariablesNotDefined "${parseArguments_variableNames[@]}"
+	exitIfVariablesNotDeclared "${parseArguments_variableNames[@]}"
 
 	local -ri parseArguments_arrLength="${#parseArguments_paramArr[@]}"
 

--- a/src/utility/parse-fn-args.sh
+++ b/src/utility/parse-fn-args.sh
@@ -127,7 +127,7 @@ function parseFnArgs() {
 		exit 9
 	fi
 
-	exitIfVariablesNotDefined "${parseFnArgs_paramArr1[@]}"
+	exitIfVariablesNotDeclared "${parseFnArgs_paramArr1[@]}"
 
 	for ((parseFnArgs_i = 0; parseFnArgs_i < parseFnArgs_minExpected; ++parseFnArgs_i)); do
 		local parseFnArgs_name=${parseFnArgs_paramArr1[parseFnArgs_i]}


### PR DESCRIPTION
this way it is clear that we only check if it was declared



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/scripts/blob/v3.3.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
