### PR TITLE
use importGpg rather than own logic in release-files

### DIFF
--- a/src/releasing/release-files.sh
+++ b/src/releasing/release-files.sh
@@ -162,8 +162,7 @@ function releaseFiles() {
 		mkdir "$gpgDir"
 		chmod 700 "$gpgDir"
 
-		gpg --homedir "$gpgDir" --batch --no-tty --import "$gtDir/signing-key.public.asc" || die "was not able to import %s" "$gtDir/signing-key.public.asc"
-		trustGpgKey "$gpgDir" "info@tegonal.com" || logInfo "could not trust key with id info@tegonal.com, you will see warnings due to this during signing the files"
+		importGpgKey "$gpgDir" "$gtDir/signing-key.public.asc" || die "was not able to import the signing-key, cannot release"
 
 		local script
 		"$release_files_findForSigning" -type f -not -name "*.sig" -print0 |


### PR DESCRIPTION
this way we also don't trust hard-coded the key of info@tegonal.com but instead the imported key.



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/scripts/blob/v4.6.1/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
