### PR TITLE
capture exit code of callback and return at the end

### DIFF
--- a/src/utility/io.sh
+++ b/src/utility/io.sh
@@ -76,10 +76,12 @@ function withCustomOutputInput() {
 	# same same if $withCustomOutputInput_fun should fail/exit, we don't setup a trap, the system should clean it up
 	rm "$withCustomOutputInput_tmpFile" || true
 
-	$withCustomOutputInput_fun "$@"
+	local exitCode=0
+	$withCustomOutputInput_fun "$@" || exitCode=$?
 
 	eval "exec ${withCustomOutputInput_outputNr}>&-"
 	eval "exec ${withCustomOutputInput_inputNr}<&-"
+	return "$exitCode"
 }
 
 function deleteDirChmod777() {


### PR DESCRIPTION
because should set -e be disabled when withCustomOutputInput is called (which can happen for various reasons: on the left side of || in an if, function which uses withCustomOutputInput happens to be in an if etc. we would no longer exit.



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/scripts/blob/v4.7.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
