### PR TITLE
checkPathNamedIsInsideOf: fix wrong variable usage in case of an error

### DIFF
--- a/src/utility/checks.sh
+++ b/src/utility/checks.sh
@@ -356,7 +356,7 @@ function checkPathNamedIsInsideOf() {
 	parseFnArgs params "$@" || return $?
 
 	if ! checkPathIsInsideOf "$path" "$rootDir"; then
-		returnDying "the given \033[0;36m%s\033[0m %s not inside of %s" "$name" "$pathAbsolute" "$rootDir" || return $?
+		returnDying "the given \033[0;36m%s\033[0m %s is not inside of %s" "$name" "$path" "$rootDir" || return $?
 	fi
 }
 


### PR DESCRIPTION

______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/scripts/blob/v4.8.1/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
