### PR TITLE
Fix: Only match full tags in pre release checks.

### DIFF
--- a/src/releasing/pre-release-checks-git.sh
+++ b/src/releasing/pre-release-checks-git.sh
@@ -64,7 +64,7 @@ function preReleaseCheckGit() {
 
 	local tags
 	tags=$(git tag) || die "The following command failed (see above): git tag"
-	if grep -q --fixed-strings "$version" <<<"$tags"; then
+	if grep -q --fixed-strings --line-regexp "$version" <<<"$tags"; then
 		logError "tag %s already exists locally, adjust version or delete it with git tag -d %s" "$version" "$version"
 		if hasRemoteTag "$version"; then
 			printf >&2 "Note, it also exists on the remote which means you also need to delete it there -- e.g. via git push origin :%s\n" "$version"


### PR DESCRIPTION
When releasing vA.B.C the check should only fail if there is a git tag that matches "vA.B.C" exactly and not "vA.B.C-RC1", for example.



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/scripts/blob/v4.12.1/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
